### PR TITLE
Use gobcore.model fields in API

### DIFF
--- a/src/gobapi/storage.py
+++ b/src/gobapi/storage.py
@@ -68,7 +68,7 @@ def _entity_to_dict(entity, model):
     :return:
     """
 
-    return {k: _to_gob_value(entity, k, v) for k, v in model['attributes'].items()}
+    return {k: _to_gob_value(entity, k, v) for k, v in model['fields'].items()}
 
 
 def get_entities(collection_name, offset, limit):

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -7,7 +7,7 @@ Flask==1.0.2
 Flask-Cors==3.0.6
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.2.6#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.2.10#egg=gobcore
 Jinja2==2.10
 MarkupSafe==1.0
 mccabe==0.6.1

--- a/src/tests/test_storage.py
+++ b/src/tests/test_storage.py
@@ -79,6 +79,16 @@ def mock_get_gobmodel():
                             'type': 'GOB.String',
                             'description': 'Some attribute'
                         }
+                    },
+                    'fields': {
+                        'id': {
+                            'type': 'GOB.String',
+                            'description': 'Unique id of the collection'
+                        },
+                        'attribute': {
+                            'type': 'GOB.String',
+                            'description': 'Some attribute'
+                        }
                     }
                 }
             }[name]


### PR DESCRIPTION
The gobcore model was being used and thus trying to get the model attributes instead of the correct databasefields. Also bumped the gobcore version to the latest release