### PR TITLE
Add timeslots endpoint for history

### DIFF
--- a/src/gobapi/states.py
+++ b/src/gobapi/states.py
@@ -1,0 +1,219 @@
+import datetime
+
+from gobcore.model import GOBModel
+from gobcore.typesystem import get_gob_type
+
+from gobapi.storage import get_collection_states, _get_convert_for_state
+
+
+RELATED_COLLECTION_FIELDS = [
+    'identificatie',
+    'volgnummer',
+    'code',
+    'naam',
+]
+
+
+def _get_valid_state_in_timeslot(timeslot_start, timeslot_end, states):
+    """Gets a valid state for a given timeslot from a list of states
+
+    Returns a state.
+
+    :param timeslot_start: The start date of the timeslot
+    :param timeslot_end: The end date of the timeslot
+    :param states: A list of states
+    :return state: A valid state
+    """
+    for state in states:
+        state_end = state.datum_einde_geldigheid if state.datum_einde_geldigheid \
+                                                 else datetime.date(9999, 12, 31)
+        if state.datum_begin_geldigheid <= timeslot_start and state_end > timeslot_start:
+            return state
+    return None
+
+
+def _get_valid_states_in_timeslot(timeslot_start, timeslot_end, collection_name,
+                                  entity_id, relations, collections_with_state):
+    """Gets all valid states for a given timeslot from a related collections
+    The function is recursive to loop through all relations.
+
+    Returns a list of valid states for each collection.
+
+    :param timeslot_start: The start date of the timeslot
+    :param timeslot_end: The end date of the timeslot
+    :param collection_name: The name of the collection to search for
+    :param entity_id: The current entity to search the valid state in
+    :param relations: A dictionary for relations between the given collections
+    :param collections_with_state: A dictionary with all states grouped by collection name
+    :return valid states: A dict containing all valid entities grouped by timeslot
+    """
+    valid_states = {}
+
+    # Get the states for the given entity id in the collection
+    states = collections_with_state[collection_name][entity_id]
+    valid_states[collection_name] = _get_valid_state_in_timeslot(timeslot_start, timeslot_end, states)
+
+    # Try to get a related entity in another collection and try to find a valid state by calling this function again
+    if collection_name in relations and valid_states[collection_name]:
+        for field, relation in relations[collection_name].items():
+            try:
+                relation_entity_id = getattr(valid_states[collection_name], field)['id']
+            except KeyError:
+                pass
+            else:
+                valid_states.update(_get_valid_states_in_timeslot(timeslot_start,
+                                                                  timeslot_end,
+                                                                  relation,
+                                                                  relation_entity_id,
+                                                                  relations,
+                                                                  collections_with_state))
+
+    return valid_states
+
+
+def _calculate_timeslots_for_entity(states, relations, collection_name,  # noqa: C901
+                                   collections_with_state, timeslot_end=None):
+    """Calculate all timeslots for an entity
+    The function is recursive to loop through all relations.
+
+    Returns a set of timeslots
+
+    :param states: All states for the entity
+    :param relations: A dictionary for relations between the given collections
+    :param collection_name: The name of the collection to search for
+    :param collections_with_state: A dictionary with all states grouped by collection name
+    :param timeslot_end: An optional end date of the timeslot, empty only on the first pass to
+        only add timeslots if they fit within the range of the main entity
+    :return valid states: A dict containing all valid entities grouped by timeslot
+    """
+    timeslots = []
+    for state in states:
+        # If we are searching within a timeslot with an end, skip this state if it starts on or after the end
+        if timeslot_end and state.datum_begin_geldigheid >= timeslot_end:
+            continue
+        timeslots.append(state.datum_begin_geldigheid)
+
+        # Add the end date if it's set
+        if state.datum_einde_geldigheid:
+            timeslots.append(state.datum_einde_geldigheid)
+
+        # If we have a relation, get all timeslots for that related entity, within the current timeslot
+        if collection_name in relations:
+
+            # Get the states timeslot end
+            state_end = state.datum_einde_geldigheid if state.datum_einde_geldigheid \
+                                                     else datetime.date(9999, 12, 31)
+
+            for field, relation in relations[collection_name].items():
+                try:
+                    relation_entity_id = getattr(state, field)['id']
+                except KeyError:
+                    pass
+                else:
+                    timeslots.extend(_calculate_timeslots_for_entity(
+                                        collections_with_state[relation][relation_entity_id],
+                                        relations,
+                                        relation,
+                                        collections_with_state,
+                                        state_end))
+    # Return unique sorted timeslots
+    return sorted(set(timeslots))
+
+
+def _find_relations(collections):
+    """Find all relations between a list of collections
+
+    Returns a dict of relation by collection and field name
+
+    :param collections: A list of collections
+    :return relations: A dict of relations
+    """
+    relations = {}
+    for collection in collections:
+        collection_name = f"{collection[0]}:{collection[1]}"
+        relations[collection_name] = {}
+        model_references = GOBModel().get_collection(collection[0], collection[1])['references']
+        for field_name, reference in model_references.items():
+            relations[collection_name][field_name] = reference['ref']
+
+    return relations
+
+
+def get_states(collections):  # noqa: C901
+    """Get states for a list of collections
+
+    Returns all timeslots and the related entities which are valid for each timeslot from the specified collections.
+
+    :param collections: A list of lists containing catalog and collection
+    :return states: A dict containing all valid entities grouped by cycle
+    """
+    # Get all relations for the specified collections
+    relations = _find_relations(collections)
+
+    primary_collection_name = f"{collections[0][0]}:{collections[0][1]}"
+
+    collections_with_state = {
+        f"{collection[0]}:{collection[1]}": get_collection_states(
+            collection[0], collection[1]) for collection in collections
+    }
+
+    entities_with_timeslots = {}
+
+    # Get the timeslots for each entity
+    for entity_id, states in collections_with_state[primary_collection_name].items():
+        unique_timeslots = _calculate_timeslots_for_entity(states,
+                                                           relations,
+                                                           primary_collection_name,
+                                                           collections_with_state)
+        # Save the unique timeslots for each entity
+        entities_with_timeslots[entity_id] = unique_timeslots
+
+    timeslot_rows = []
+    # for each timeslot get the valid state and related states
+    for entity_id, timeslots in entities_with_timeslots.items():
+        for count, timeslot in enumerate(timeslots):
+            timeslot_start = timeslot
+            timeslot_end = timeslots[count+1] if count+1 < len(timeslots) else datetime.date(9999, 12, 31)
+
+            valid_states = _get_valid_states_in_timeslot(timeslot_start,
+                                                         timeslot_end,
+                                                         primary_collection_name,
+                                                         entity_id,
+                                                         relations,
+                                                         collections_with_state)
+
+            # First fill the primary state
+            catalog_name, collection_name = primary_collection_name.split(':')
+            model = GOBModel().get_collection(catalog_name, collection_name)
+            entity_convert = _get_convert_for_state(model)
+
+            # Only add a row if a valid state has been found for the primary collection
+            if(valid_states[primary_collection_name]):
+                row = entity_convert(valid_states.pop(primary_collection_name))
+
+                gob_date = get_gob_type("GOB.Date")
+
+                row['begin_tijdvak'] = gob_date.from_value(timeslot_start)
+                row['einde_tijdvak'] = gob_date.from_value(
+                    timeslot_end if timeslot_end != datetime.date(9999, 12, 31) else None)
+                # Add the related states, so skip the first collection
+                itercollections = iter(collections)
+                next(itercollections)
+                for collection in itercollections:
+                    collection_name = ':'.join(collection)
+                    model = GOBModel().get_collection(*collection)
+
+                    entity_convert = _get_convert_for_state(model,
+                                                            RELATED_COLLECTION_FIELDS)
+                    try:
+                        related_row = entity_convert(valid_states[collection_name])
+                        related_row = {f'{collection_name}_{k}': v for k, v in related_row.items()}
+                        row.update(related_row)
+                    except KeyError:
+                        # If a relation can't be found, add null values
+                        related_row = {f'{collection_name}_{k}': None for k in RELATED_COLLECTION_FIELDS}
+                        row.update(related_row)
+
+                timeslot_rows.append(row)
+
+    return timeslot_rows, len(timeslot_rows)

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -10,7 +10,7 @@ Flask-GraphQL==2.0.0
 Flask-SQLAlchemy==2.3.2
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.5.20#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.5.26#egg=gobcore
 graphene==2.1.3
 graphene-sqlalchemy==2.1.0
 graphql-core==2.1

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -114,6 +114,8 @@ def before_each_api_test(monkeypatch):
     monkeypatch.setattr(gobapi.storage, 'get_entities', mock_entities)
     monkeypatch.setattr(gobapi.storage, 'get_entity', lambda catalog, collection, id, view: entity)
 
+    monkeypatch.setattr(gobapi.states, 'get_states', lambda collections: ([{'id': '1', 'attribute': 'attribute'}], 1))
+
     monkeypatch.setattr(gobcore.model, 'GOBModel', MockGOBModel)
 
     import gobapi.api
@@ -121,6 +123,9 @@ def before_each_api_test(monkeypatch):
 
     import gobapi.storage
     importlib.reload(gobapi.storage)
+
+    import gobapi.states
+    importlib.reload(gobapi.states)
 
 
 def test_app(monkeypatch):
@@ -302,6 +307,33 @@ def test_collection_with_view(monkeypatch):
              'previous': None}
         ), 200, {'Content-Type': 'application/json'}))
 
+
+def test_states(monkeypatch):
+    global mockRequest
+    global catalog, collection
+    global entities, entity
+
+    before_each_api_test(monkeypatch)
+
+    from gobapi.api import _states
+    assert(_states() == 'No collections requested')
+
+    catalog = 'catalog'
+    collection = {'references': {}}
+
+    mockRequest.args = {
+        'collections': 'catalog:collection'
+    }
+    assert(_states() == (
+        ({
+             'page_size': 1,
+             'pages': 1,
+             'results': [{'id': '1', 'attribute': 'attribute'}],
+             'total_count': 1
+         },{
+             'next': None,
+            'previous': None}
+        ), 200, {'Content-Type': 'application/json'}))
 
 
 def test_health(monkeypatch):

--- a/src/tests/test_states.py
+++ b/src/tests/test_states.py
@@ -1,0 +1,205 @@
+""""States Unit tests
+
+The unit tests for the states module.
+As it is a unit test all external dependencies are mocked
+
+"""
+import datetime
+import importlib
+
+
+class MockGOBModel:
+    def __init__(self):
+        self.model = {
+            'catalog': {
+                'collection': {
+                    'fields': {
+                        'volgnummer': {'type': 'GOB.String'},
+                        'identificatie': {'type': 'GOB.String'},
+                        'naam': {'type': 'GOB.String'},
+                        'code': {'type': 'GOB.String'},
+                    },
+                    'references': {
+                        'reference': {
+                            'ref': 'catalog:collection2'
+                        }
+                    }
+                },
+                'collection2': {
+                    'fields': {
+                        'volgnummer': {'type': 'GOB.String'},
+                        'identificatie': {'type': 'GOB.String'},
+                        'naam': {'type': 'GOB.String'},
+                        'code': {'type': 'GOB.String'},
+                    },
+                    'references': {}
+                }
+            }
+        }
+        pass
+
+    def get_collection(self, catalog_name, collection_name):
+        return self.model[catalog_name][collection_name]
+
+
+class MockState:
+    def __init__(self, kwargs={}):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+collections = [['catalog', 'collection'], ['catalog', 'collection2']]
+
+collection_name = 'catalog:collection'
+
+relations = {
+    'catalog:collection': {
+        'reference': 'catalog:collection2'
+    },
+    'catalog:collection2': {}
+}
+
+states_collection = [
+    MockState({
+        'volgnummer': 1,
+        'identificatie': '1',
+        'naam': 'Naam',
+        'code': 'A',
+        'datum_begin_geldigheid': datetime.date(2010, 1, 1),
+        'datum_einde_geldigheid': datetime.date(2011, 1, 1),
+        'reference': {'id': '1'}
+    }),
+    MockState({
+        'volgnummer': 2,
+        'identificatie': '1',
+        'naam': 'Naam',
+        'code': 'B',
+        'datum_begin_geldigheid': datetime.date(2011, 1, 1),
+        'datum_einde_geldigheid': None,
+        'reference': {}
+    })
+]
+
+states_collection2 = [
+    MockState({
+        'volgnummer': 1,
+        'identificatie': '1',
+        'naam': 'Naam2',
+        'code': 'C',
+        'datum_begin_geldigheid': datetime.date(2010, 1, 1),
+        'datum_einde_geldigheid': datetime.date(2012, 1, 1),
+        'reference': {'id': '1'}
+    }),
+    MockState({
+        'volgnummer': 2,
+        'identificatie': '1',
+        'naam': 'Naam2',
+        'code': 'D',
+        'datum_begin_geldigheid': datetime.date(2012, 1, 1),
+        'datum_einde_geldigheid': None
+    })
+]
+
+collections_with_state = {
+    'catalog:collection': {
+        '1': states_collection
+    },
+    'catalog:collection2': {
+        '1': states_collection2
+    }
+}
+
+
+def before_each_state_test(monkeypatch):
+    global collections_with_state
+
+    import gobcore.model
+    import gobapi.storage
+
+    monkeypatch.setattr(gobapi.storage, 'get_collection_states', lambda catalog, collection: collections_with_state[f'{catalog}:{collection}'])
+    monkeypatch.setattr(gobcore.model, 'GOBModel', MockGOBModel)
+
+    import gobapi.states
+    importlib.reload(gobapi.states)
+
+
+
+def test_get_valid_states_in_timeslot(monkeypatch):
+    before_each_state_test(monkeypatch)
+    global relations, collections_with_state
+
+    from gobapi.states import _get_valid_states_in_timeslot
+
+    # Test invalid timeslot
+    timeslot_start = datetime.date(2009, 1, 1)
+    timeslot_end = datetime.date(2010, 1, 1)
+
+    entity_id = '1'
+
+    result = _get_valid_states_in_timeslot(timeslot_start, timeslot_end, collection_name,
+                                     entity_id, relations, collections_with_state)
+    assert(result == {'catalog:collection': None})
+
+    # Test timeslot with relation
+    timeslot_start = datetime.date(2010, 1, 1)
+    timeslot_end = datetime.date(2010, 6, 1)
+    result = _get_valid_states_in_timeslot(timeslot_start, timeslot_end, collection_name,
+                                     entity_id, relations, collections_with_state)
+
+    assert(result == {
+        'catalog:collection': states_collection[0],
+        'catalog:collection2': states_collection2[0]
+    })
+
+    # Test timeslot without relation
+    timeslot_start = datetime.date(2011, 1, 1)
+    timeslot_end = datetime.date(2012, 1, 1)
+    result = _get_valid_states_in_timeslot(timeslot_start, timeslot_end, collection_name,
+                                     entity_id, relations, collections_with_state)
+
+    assert(result == {
+        'catalog:collection': states_collection[1]
+    })
+
+
+def test_calculate_timeslots_for_entity(monkeypatch):
+    before_each_state_test(monkeypatch)
+    global relations, collections_with_state, states_collection
+
+    from gobapi.states import _calculate_timeslots_for_entity
+
+    result = _calculate_timeslots_for_entity(states_collection, relations,
+                                             collection_name, collections_with_state)
+    assert(result == [
+        datetime.date(2010,1,1),
+        datetime.date(2011,1,1),
+        datetime.date(2012,1,1)
+    ])
+
+
+def test_find_relations(monkeypatch):
+    before_each_state_test(monkeypatch)
+
+    global collections, relations
+
+    from gobapi.states import _find_relations
+
+    result = _find_relations(collections)
+    assert(result == relations)
+
+
+def test_get_states(monkeypatch):
+    before_each_state_test(monkeypatch)
+
+    global collections, relations
+
+    from gobapi.states import get_states
+
+    result = get_states(collections)
+    print(result)
+    assert(result == ([
+        {'volgnummer': '1', 'identificatie': '1', 'naam': 'Naam', 'code': 'A', 'begin_tijdvak': datetime.date(2010,1,1), 'einde_tijdvak': datetime.date(2011,1,1), 'catalog:collection2_volgnummer': '1', 'catalog:collection2_identificatie': '1', 'catalog:collection2_naam': 'Naam2', 'catalog:collection2_code': 'C'},
+        {'volgnummer': '2', 'identificatie': '1', 'naam': 'Naam', 'code': 'B', 'begin_tijdvak': datetime.date(2011,1,1), 'einde_tijdvak': datetime.date(2012,1,1), 'catalog:collection2_volgnummer': '1', 'catalog:collection2_identificatie': '1', 'catalog:collection2_naam': 'Naam2', 'catalog:collection2_code': 'C'},
+        {'volgnummer': '2', 'identificatie': '1', 'naam': 'Naam', 'code': 'B', 'begin_tijdvak': datetime.date(2012,1,1), 'einde_tijdvak': None, 'catalog:collection2_volgnummer': '2', 'catalog:collection2_identificatie': '1', 'catalog:collection2_naam': 'Naam2', 'catalog:collection2_code': 'D'}
+    ]
+    ), 3)

--- a/src/tests/test_storage.py
+++ b/src/tests/test_storage.py
@@ -4,10 +4,12 @@ The unit tests for the storage module.
 As it is a unit test all external dependencies are mocked
 
 """
+import datetime
 import importlib
 import sqlalchemy
 import sqlalchemy_filters
 
+from gobapi.storage import _get_convert_for_state
 
 class MockClasses:
     def __init__(self):
@@ -24,21 +26,23 @@ class MockBase:
 
 class MockEntity:
     def __init__(self, *args):
-        self._id = 1
+        self._id = '1'
         self.reference = {
-            'id': 1,
-            'bronwaarde': 1
+            'id': '1',
+            'bronwaarde': '1'
         }
         self.manyreference = [
             {
-                'id': 1,
-                'bronwaarde': 1
+                'id': '1',
+                'bronwaarde': '1'
             },
             {
-                'id': 2,
-                'bronwaarde': 2
+                'id': '2',
+                'bronwaarde': '2'
             }
         ]
+        self.datum_begin_geldigheid = datetime.date.today() - datetime.timedelta(days=365)
+        self.datum_einde_geldigheid = datetime.date.today()
         for key in args:
             setattr(self, key, key)
 
@@ -258,10 +262,10 @@ def test_entities_with_references(monkeypatch):
             'self': {'href': '/gob/catalog/collection2/1/'}
         },
         '_embedded': {
-            'reference': {'bronwaarde': 1, 'id': 1, '_links': {'self': {'href': '/gob/catalog/collection/1/'}}},
+            'reference': {'bronwaarde': '1', 'id': '1', '_links': {'self': {'href': '/gob/catalog/collection/1/'}}},
             'manyreference': [
-                {'bronwaarde': 1, 'id': 1, '_links': {'self': {'href': '/gob/catalog/collection2/1/'}}},
-                {'bronwaarde': 2, 'id': 2, '_links': {'self': {'href': '/gob/catalog/collection2/2/'}}}
+                {'bronwaarde': '1', 'id': '1', '_links': {'self': {'href': '/gob/catalog/collection2/1/'}}},
+                {'bronwaarde': '2', 'id': '2', '_links': {'self': {'href': '/gob/catalog/collection2/2/'}}}
             ]
         }
     }], 1))
@@ -283,10 +287,10 @@ def test_entities_without_reference_id(monkeypatch):
             'self': {'href': '/gob/catalog/collection2/1/'}
         },
         '_embedded': {
-            'reference': {'bronwaarde': 1, 'id': None},
+            'reference': {'bronwaarde': '1', 'id': None},
             'manyreference': [
-                {'bronwaarde': 1, 'id': 1, '_links': {'self': {'href': '/gob/catalog/collection2/1/'}}},
-                {'bronwaarde': 2, 'id': 2, '_links': {'self': {'href': '/gob/catalog/collection2/2/'}}}
+                {'bronwaarde': '1', 'id': '1', '_links': {'self': {'href': '/gob/catalog/collection2/1/'}}},
+                {'bronwaarde': '2', 'id': '2', '_links': {'self': {'href': '/gob/catalog/collection2/2/'}}}
             ]
         }
     }], 1))
@@ -310,6 +314,21 @@ def test_entities_with_view(monkeypatch):
         mockEntity
     ]
     assert(get_entities('catalog', 'collection1', 0, 1, 'enhanced') == ([{'attribute': 'attribute', 'id': 'id'}], 1))
+
+
+def test_collection_states(monkeypatch):
+    before_each_storage_test(monkeypatch)
+
+    from gobapi.storage import get_collection_states
+    MockEntities.all_entities = []
+    assert(get_collection_states('catalog', 'collection1') == {})
+
+    mockEntity = MockEntity('id', 'attribute')
+    MockEntities.all_entities = [
+        mockEntity
+    ]
+
+    assert(get_collection_states('catalog', 'collection1') == {'1': [mockEntity]})
 
 
 def test_entity(monkeypatch):
@@ -342,3 +361,15 @@ def test_teardown_session(monkeypatch):
     assert(session._remove == False)
     shutdown_session()
     assert(session._remove == True)
+
+
+def test_get_convert_for_state(monkeypatch):
+    before_each_storage_test(monkeypatch)
+
+    MockGOBModel = mock_get_gobmodel()
+    model = MockGOBModel.get_collection('catalog', 'collection1')
+    convert = _get_convert_for_state(model)
+    mockEntity = MockEntity('id', 'attribute')
+    result = convert(mockEntity)
+
+    assert(result == {'id': 'id', 'attribute': 'attribute'})


### PR DESCRIPTION
Timeslots were added to provide a generic way to export entities with history. Timeslots are calculated for each change in both the entity and it’s requested relations.

Some functions are too complex, so maybe we can refactor some things. Would be good to get another opinion on the current status