### PR TITLE
Add pagination to states endpoint

### DIFF
--- a/src/gobapi/api.py
+++ b/src/gobapi/api.py
@@ -178,20 +178,28 @@ def _states():
     :return:
     """
     collection_names = request.args.get('collections')
+    page = int(request.args.get('page', 1))
+    page_size = int(request.args.get('page_size', 100))
+    offset = (page - 1) * page_size
+
     if collection_names:
         collections = []
         for c in collection_names.split(','):
             collections.append(c.split(':'))
-            entities, total_count = get_states(collections)
+
+        entities, total_count = get_states(collections, offset=offset, limit=page_size)
+
+        num_pages = (total_count + page_size - 1) // page_size
+
         result = {
             'total_count': total_count,
-            'page_size': total_count,
-            'pages': 1,
+            'page_size': page_size,
+            'pages': num_pages,
             'results': entities
         }
         links = {
-            'next': None,
-            'previous': None
+            'next': get_page_ref(page + 1, num_pages),
+            'previous': get_page_ref(page - 1, num_pages)
             }
         return hal_response(result, links)
     else:

--- a/src/gobapi/states.py
+++ b/src/gobapi/states.py
@@ -147,6 +147,18 @@ def _find_relations(collections):
 
 def _build_timeslot_rows(collections, entities_with_timeslots, primary_collection_name,    # noqa: C901
                          relations, collections_with_state, offset, limit):
+    """Builds the output of the timeslot rows within the given offset and limit.
+    A timeslot row is a state for an entity within a certain timeslot.
+
+    Returns a list timeslot rows and the total count of timeslot rows
+
+    :param collections: The collections for which states are returned
+    :param entities_with_timeslots: A dict of timeslots grouped by entity id
+    :param primary_collection_name: The name of the base collection we are exporting
+    :param relations: A dictionary for relations between the given collections
+    :param collections_with_state: A dictionary with all states grouped by collection name
+    :return timeslot_rows, total_count: A list of timeslot rows and the total count of timeslot rows
+    """
     row_count = 0
     timeslot_rows = []
 
@@ -167,6 +179,7 @@ def _build_timeslot_rows(collections, entities_with_timeslots, primary_collectio
             # Only add a row if a valid state has been found for the primary collection
             if(valid_states[primary_collection_name]):
                 row_count += 1
+                # Don't store the row if it doesn't match the requested offset and limit
                 if row_count <= offset or (row_count-offset) > limit:
                     continue
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -10,7 +10,7 @@ Flask-GraphQL==2.0.0
 Flask-SQLAlchemy==2.3.2
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.5.26#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.5.27#egg=gobcore
 graphene==2.1.3
 graphene-sqlalchemy==2.1.0
 graphql-core==2.1

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -114,7 +114,7 @@ def before_each_api_test(monkeypatch):
     monkeypatch.setattr(gobapi.storage, 'get_entities', mock_entities)
     monkeypatch.setattr(gobapi.storage, 'get_entity', lambda catalog, collection, id, view: entity)
 
-    monkeypatch.setattr(gobapi.states, 'get_states', lambda collections: ([{'id': '1', 'attribute': 'attribute'}], 1))
+    monkeypatch.setattr(gobapi.states, 'get_states', lambda collections, offset, limit: ([{'id': '1', 'attribute': 'attribute'}], 1))
 
     monkeypatch.setattr(gobcore.model, 'GOBModel', MockGOBModel)
 
@@ -326,7 +326,7 @@ def test_states(monkeypatch):
     }
     assert(_states() == (
         ({
-             'page_size': 1,
+             'page_size': 100,
              'pages': 1,
              'results': [{'id': '1', 'attribute': 'attribute'}],
              'total_count': 1

--- a/src/tests/test_states.py
+++ b/src/tests/test_states.py
@@ -205,9 +205,12 @@ def test_get_states(monkeypatch):
 
     from gobapi.states import get_states
 
-    result = get_states(collections)
+    offset = 0
+    limit = 100
+    result = get_states(collections, offset, limit)
 
-    # Make sure 3 records are returned
+    # Make sure 4 records are returned
+    assert(len(result[0]) == 4)
     assert(result[1] == 4)
 
     expected_outcome = [
@@ -222,3 +225,12 @@ def test_get_states(monkeypatch):
         for key, value in row.items():
             print(index, key, value)
             assert(str(value) == str(expected_outcome[index][key]))
+
+    # Test offset
+    offset = 0
+    limit = 1
+    result = get_states(collections, offset, limit)
+
+    # Make sure 1 record is returned and total count is 4
+    assert(len(result[0]) == 1)
+    assert(result[1] == 4)


### PR DESCRIPTION
The api output of states is now paginated.  This was needed to be able to export large collections. 