### PR TITLE
Output DateTime as isoformat in API

### DIFF
--- a/src/gobapi/json.py
+++ b/src/gobapi/json.py
@@ -1,0 +1,24 @@
+import datetime
+
+from gobcore.typesystem.json import GobTypeJSONEncoder
+from gobcore.typesystem.gob_types import DateTime
+
+
+class APIGobTypeJSONEncoder(GobTypeJSONEncoder):
+    """Extension of the GobTypeJSONEncoder to help turn the internal format of
+     datetime in to isoformat
+
+    Use as follows:
+
+        import json
+
+        gob_type = DateTime.from_value('2019-01-01T12:00:00.123456')
+        json.dumps(gob_type, cls=APIGobTypeJSONEncoder)
+    """
+
+    def default(self, obj):
+        if isinstance(obj, DateTime):
+            return datetime.datetime.strptime(str(obj), DateTime.internal_format).isoformat() \
+                    if obj._string is not None else obj.json
+
+        return super().default(obj)

--- a/src/gobapi/response.py
+++ b/src/gobapi/response.py
@@ -17,7 +17,7 @@ import json
 import urllib
 
 from flask import request
-from gobcore.typesystem.json import GobTypeJSONEncoder
+from gobapi.json import APIGobTypeJSONEncoder
 
 
 def _to_camelcase(s):
@@ -96,7 +96,7 @@ def hal_response(data, links={}):
         **data
     })
 
-    return json.dumps(response, cls=GobTypeJSONEncoder), 200, {'Content-Type': 'application/json'}
+    return json.dumps(response, cls=APIGobTypeJSONEncoder), 200, {'Content-Type': 'application/json'}
 
 
 def not_found(msg):

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -10,7 +10,7 @@ Flask-GraphQL==2.0.0
 Flask-SQLAlchemy==2.3.2
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.5.27#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.5.29#egg=gobcore
 graphene==2.1.3
 graphene-sqlalchemy==2.1.0
 graphql-core==2.1

--- a/src/tests/test_json.py
+++ b/src/tests/test_json.py
@@ -1,0 +1,21 @@
+import json
+import unittest
+
+from gobcore.typesystem.gob_types import DateTime, String
+from gobapi.json import APIGobTypeJSONEncoder
+
+class TestJsonEncoding(unittest.TestCase):
+
+    def test_json(self):
+        gob_type = DateTime.from_value("2019-01-01T10:00:00.123456")
+        to_json = json.dumps({'datetime': gob_type}, cls=APIGobTypeJSONEncoder)
+        self.assertEqual('{"datetime": "2019-01-01T10:00:00.123456"}', to_json)
+
+        gob_type = DateTime.from_value("2019-01-01T10:00:00.000000")
+        to_json = json.dumps({'datetime': gob_type}, cls=APIGobTypeJSONEncoder)
+        self.assertEqual('{"datetime": "2019-01-01T10:00:00"}', to_json)
+
+        # Test is other types use the regular JSONEncoder
+        gob_type = String.from_value(123)
+        to_json = json.dumps({'string': gob_type}, cls=APIGobTypeJSONEncoder)
+        self.assertEqual('{"string": "123"}', to_json)


### PR DESCRIPTION
In the JSON output, datetime was being outputted according to the internal format. This would result in unnecessary microseconds in a lot of dates according to the iso standard. This commit fixes this issue by extending the current JSON Encoder