### PR TITLE
Fix relations in states endpoint

### DIFF
--- a/src/gobapi/json.py
+++ b/src/gobapi/json.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 
 from gobcore.typesystem.json import GobTypeJSONEncoder
 from gobcore.typesystem.gob_types import DateTime
@@ -19,6 +20,5 @@ class APIGobTypeJSONEncoder(GobTypeJSONEncoder):
     def default(self, obj):
         if isinstance(obj, DateTime):
             return datetime.datetime.strptime(str(obj), DateTime.internal_format).isoformat() \
-                    if obj._string is not None else obj.json
-
+                    if obj._string is not None else json.loads(obj.json)
         return super().default(obj)

--- a/src/gobapi/states.py
+++ b/src/gobapi/states.py
@@ -60,7 +60,7 @@ def _get_valid_states_in_timeslot(timeslot_start, timeslot_end, collection_name,
     if collection_name in relations and valid_states[collection_name]:
         for field, relation in relations[collection_name].items():
             try:
-                relation_entity_id = getattr(valid_states[collection_name], field)['id']
+                relation_entity_id = getattr(valid_states[collection_name], field)['identificatie']
             except KeyError:
                 # If no relation is found, skip checking for other relations
                 pass
@@ -110,7 +110,7 @@ def _calculate_timeslots_for_entity(states, relations, collection_name,  # noqa:
 
             for field, relation in relations[collection_name].items():
                 try:
-                    relation_entity_id = getattr(state, field)['id']
+                    relation_entity_id = getattr(state, field)['identificatie']
                 except KeyError:
                     pass
                 else:

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -10,7 +10,7 @@ Flask-GraphQL==2.0.0
 Flask-SQLAlchemy==2.3.2
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.5.38b#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.5.40a#egg=gobcore
 graphene==2.1.3
 graphene-sqlalchemy==2.1.0
 graphql-core==2.1

--- a/src/tests/test_states.py
+++ b/src/tests/test_states.py
@@ -68,7 +68,7 @@ states_collection = [
         'code': 'A',
         'begin_geldigheid': datetime.date(2010, 1, 1),
         'eind_geldigheid': datetime.date(2011, 1, 1),
-        'reference': {'id': '1'}
+        'reference': {'identificatie': '1'}
     }),
     MockState({
         'volgnummer': 2,
@@ -77,7 +77,7 @@ states_collection = [
         'code': 'B',
         'begin_geldigheid': datetime.date(2011, 1, 1),
         'eind_geldigheid': datetime.date(2013, 1, 1),
-        'reference': {'id': '1'}
+        'reference': {'identificatie': '1'}
     }),
     MockState({
         'volgnummer': 3,


### PR DESCRIPTION
The relations in the state endpoint were broken, because it was still connecting on ‘id’ instead of identification. A small fix was also added for the JSONEncoder. Empty datetimes were being returned as “null” instead of null.