### PR TITLE
Release 20190411

### DIFF
--- a/src/gobapi/storage.py
+++ b/src/gobapi/storage.py
@@ -163,12 +163,14 @@ def _get_convert_for_model(catalog, collection, model, meta={}, private_attribut
         if model['references']:
             hal_entity['_embedded'] = {k: _create_reference(entity, k, v)
                                        for k, v in model['references'].items()
-                                       if not k.startswith('_') or private_attributes}
+                                       if (not k.startswith('_') and not v.get('hidden')) or private_attributes}
+
         return hal_entity
     # Get the attributes which are not a reference, exclude private_attributes unless specifically requested
     attributes = {k: v for k, v in model['fields'].items()
                   if k not in model['references'].keys()
-                  and (not k.startswith('_') or private_attributes)}
+                  and (not k.startswith('_') or private_attributes)
+                  and not v.get('hidden')}
 
     items = list(attributes.items()) + list(meta.items())
     return convert

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -10,7 +10,7 @@ Flask-GraphQL==2.0.0
 Flask-SQLAlchemy==2.3.2
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.5.59e#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.5.67b#egg=gobcore
 graphene==2.1.3
 graphene-sqlalchemy==2.1.0
 graphql-core==2.1


### PR DESCRIPTION
The correct relations are now selected when querying for a reference, this allows for historic exports. Hidden attributes are not being taken into account when creating the graphql endpoint, or in the list API views