### PR TITLE
Security fix

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -17,7 +17,7 @@ graphql-core==2.1
 graphql-relay==0.4.5
 graphql-server-core==1.1.1
 itsdangerous==0.24
-Jinja2==2.10
+Jinja2==2.10.1
 MarkupSafe==1.0
 mccabe==0.6.1
 more-itertools==4.3.0


### PR DESCRIPTION
Known high severity security vulnerability detected in Jinja2 < 2.10.1
defined in requirements.txt.
requirements.txt update suggested: Jinja2 ~> 2.10.1.