### PR TITLE
Added heartbeat to API

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ if (BRANCH == "develop") {
     node {
         stage('Push develop image') {
             tryStep "image tagging", {
-                def image = docker.image("build.datapunt.amsterdam.nl:5000/datapunt/gob_api:${env.BUILD_NUMBER}")
+                def image = docker.image("datapunt/gob_api:${env.BUILD_NUMBER}")
                 image.pull()
                 image.push("develop")
             }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,14 @@ services:
     environment:
       DATABASE_PORT_OVERRIDE: 5432
       DATABASE_HOST_OVERRIDE: database
+      MESSAGE_BROKER_ADDRESS: rabbitmq
+      API_INFRA_SERVICES: MESSAGE_SERVICE
       UWSGI_HTTP: ":8000"
       UWSGI_MODULE: "gobapi.wsgi"
       UWSGI_CALLABLE: "application"
       UWSGI_MASTER: 1
+      UWSGI_ENABLE_THREADS: 1
+
 
 networks:
   default:

--- a/src/gobapi/__main__.py
+++ b/src/gobapi/__main__.py
@@ -9,5 +9,6 @@ import os
 
 from gobapi.api import get_app
 
+
 # get the API object and start it up
 get_app().run(port=os.getenv("GOB_API_PORT", 8141))

--- a/src/gobapi/config.py
+++ b/src/gobapi/config.py
@@ -15,3 +15,8 @@ GOB_DB = {
     'host': os.getenv("DATABASE_HOST_OVERRIDE", "localhost"),
     'port': os.getenv("DATABASE_PORT_OVERRIDE", 5406),
 }
+
+# see gobapi.services.registry
+API_INFRA_SERVICES = os.getenv(
+    "API_INFRA_SERVICES", ""
+).upper().split(",")

--- a/src/gobapi/config.py
+++ b/src/gobapi/config.py
@@ -18,5 +18,5 @@ GOB_DB = {
 
 # see gobapi.services.registry
 API_INFRA_SERVICES = os.getenv(
-    "API_INFRA_SERVICES", ""
+    "API_INFRA_SERVICES", "MESSAGE_SERVICE"
 ).upper().split(",")

--- a/src/gobapi/infra.py
+++ b/src/gobapi/infra.py
@@ -11,11 +11,8 @@ def start_all_services(
             registry: dict = services.registry,
             factory: ThreadFactory = services.threaded_service
         ) -> typing.List[threading.Thread]:
-    threads = []
-    for service_ident in service_idents:
-        if service_ident not in registry:
-            continue
-        threads.append(
-            factory(registry[service_ident]())
-        )
-    return threads
+    return [
+        factory(registry[service_ident]())
+        for service_ident in service_idents
+        if service_ident in registry
+    ]

--- a/src/gobapi/infra.py
+++ b/src/gobapi/infra.py
@@ -1,0 +1,21 @@
+import typing
+import threading
+
+from gobapi import services
+
+ThreadFactory = typing.Callable[[services.Service], threading.Thread]
+
+
+def start_all_services(
+            service_idents: list,
+            registry: dict = services.registry,
+            factory: ThreadFactory = services.threaded_service
+        ) -> typing.List[threading.Thread]:
+    threads = []
+    for service_ident in service_idents:
+        if service_ident not in registry:
+            continue
+        threads.append(
+            factory(registry[service_ident]())
+        )
+    return threads

--- a/src/gobapi/logger.py
+++ b/src/gobapi/logger.py
@@ -1,0 +1,11 @@
+import logging
+import os
+
+from gobcore.logging.logger import Logger
+
+
+def get_logger(name):
+    run_mode = os.getenv('GOB_RUN_MODE', 'PRODUCTION')
+    if run_mode == 'TEST':
+        return logging.getLogger(name)
+    return Logger(name)

--- a/src/gobapi/services.py
+++ b/src/gobapi/services.py
@@ -1,0 +1,92 @@
+""" Interface code to external services we run next to the API """
+
+import abc
+import atexit
+import threading
+import typing
+import signal as signallib
+
+from gobcore.logging.logger import Logger
+from gobcore.message_broker import messagedriven_service
+
+logger = Logger("gopapi.services")
+
+
+def _signal_adapter(
+            func, backend=signallib, term_signal=signallib.SIGINT):
+    prev_handler = backend.getsignal(term_signal)
+    """ Adapter for registering a teardown func in signal """
+
+    def _sig_handler(emitted_signal, frame):
+        func()
+        prev_handler(emitted_signal, frame)
+
+    try:
+        backend.signal(term_signal, _sig_handler)
+    except ValueError:
+        pass
+
+
+def _atexit_adapter(func, backend=atexit):
+    """ Adapter for registering a teardown func in atexit """
+    backend.register(func)
+
+
+class Service:
+    name = "Service"
+    backend = None
+
+    def __init__(self, backend=None):
+        if backend:
+            self.backend = backend
+
+    @abc.abstractmethod
+    def start(self):
+        """ Starts the service """
+
+    @abc.abstractmethod
+    def stop(self):
+        """ Stop the service """
+
+
+class MessageDrivenService(Service):
+    """ Interface to gobcore.message_broker.messagedriven_service """
+    name = "_MessageService"  # start with underscore then ignored by workflow
+    backend = messagedriven_service
+
+    def start(self):
+        self.backend.messagedriven_service({}, "API")
+
+    def stop(self):
+        self.backend.keep_running = False
+
+
+registry = {
+    'MESSAGE_SERVICE': MessageDrivenService
+}
+
+AdapterList = typing.List[typing.Any]
+
+DEFAULT_TEARDOWN_ADAPTERS = [_signal_adapter, _atexit_adapter]
+
+
+def threaded_service(
+            service: Service,
+            threading_backend=threading.Thread,
+            teardown_adapters: AdapterList = DEFAULT_TEARDOWN_ADAPTERS
+        ):
+    """ Start a threaded service """
+    service_thread = threading_backend(
+        target=service.start, name=service.name
+    )
+
+    def _exit():
+        logger.info(f"Stopping service {service.name}")
+        service.stop()
+        service_thread.join(4)
+
+    for adapter in teardown_adapters:
+        adapter(_exit)
+
+    service_thread.start()
+    return service_thread

--- a/src/gobapi/services.py
+++ b/src/gobapi/services.py
@@ -63,11 +63,7 @@ DEFAULT_TEARDOWN_ADAPTERS = [SignalAdapter, AtexitAdapter]
 
 class Service(abc.ABC):
     name = "Service"
-    backend = None
-
-    def __init__(self, backend=None):
-        if backend:
-            self.backend = backend
+    backend: typing.ClassVar[typing.Callable]
 
     @abc.abstractmethod
     def start(self):

--- a/src/gobapi/services.py
+++ b/src/gobapi/services.py
@@ -15,10 +15,11 @@ import threading
 import typing
 import signal as signallib
 
-from gobcore.logging.logger import Logger
 from gobcore.message_broker import messagedriven_service
 
-logger = Logger("gopapi.services")
+from gobapi.logger import get_logger
+
+logger = get_logger("gopapi.services")
 
 TeardownFunc = typing.Callable[[], None]
 TeardownAdapter = typing.Callable[[TeardownFunc], None]

--- a/src/gobapi/services.py
+++ b/src/gobapi/services.py
@@ -101,10 +101,11 @@ def threaded_service(
         target=service.start, name=service.name
     )
 
-    def _teardown_func():
+    def _teardown_func(terminate_timeout=5):
+        # default timeout is 5 since polling period in services is 5
         logger.info(f"Stopping service {service.name}")
         service.stop()
-        service_thread.join(4)
+        service_thread.join(terminate_timeout)
 
     for adapter in teardown_adapters:
         adapter(_teardown_func)

--- a/src/gobapi/wsgi.py
+++ b/src/gobapi/wsgi.py
@@ -1,3 +1,8 @@
 from gobapi.api import get_app
+from gobapi import config
+from gobapi.infra import start_all_services
+
+
+start_all_services(config.API_INFRA_SERVICES)
 
 application = get_app()

--- a/src/test.sh
+++ b/src/test.sh
@@ -6,6 +6,8 @@ set -e # stop on any error
 echo "Running style checks"
 flake8
 
+export GOB_RUN_MODE=TEST
+
 echo "Running unit tests"
 pytest
 

--- a/src/tests/test__main__.py
+++ b/src/tests/test__main__.py
@@ -1,10 +1,13 @@
 import importlib
+from unittest.mock import patch
 
 import gobapi
 importlib.reload(gobapi)
 
 import gobapi.api
 importlib.reload(gobapi.api)
+
+import gobapi.config
 
 
 class MockApp:
@@ -14,8 +17,10 @@ class MockApp:
         self.is_running = True
 
 
-def test_main(monkeypatch):
+@patch("gobapi.services.registry")
+def test_main(MockReg, monkeypatch):
     mockApp = MockApp()
+    reg = MockReg()
     monkeypatch.setattr(gobapi.api, 'get_app', lambda: mockApp)
 
     from gobapi import __main__

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -5,12 +5,16 @@ As it is a unit test all external dependencies are mocked
 
 """
 import importlib
+import os
+from unittest.mock import patch
 
 def noop(*args):
     pass
 
 
 class MockFlask:
+    running = False
+
     def __init__(self, name):
         pass
 
@@ -19,6 +23,9 @@ class MockFlask:
 
     def teardown_appcontext(self, func):
         return None
+
+    def run(self):
+        self.running = True
 
 
 class MockCORS:
@@ -128,12 +135,14 @@ def before_each_api_test(monkeypatch):
     importlib.reload(gobapi.states)
 
 
-def test_app(monkeypatch):
+@patch("gobapi.services.threaded_service")
+def test_app(Mock, monkeypatch):
     before_each_api_test(monkeypatch)
-
-
     from gobapi.api import get_app
-    assert(not get_app() == None)
+    app = get_app()
+    assert(not app == None)
+    app.run()
+    assert len(app._infra_threads) == 0
 
 
 def test_catalogs(monkeypatch):

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -138,6 +138,9 @@ def before_each_api_test(monkeypatch):
 @patch("gobapi.services.threaded_service")
 def test_app(Mock, monkeypatch):
     before_each_api_test(monkeypatch)
+    import gobapi.api
+    # override config so we isolate .run()
+    gobapi.api.API_INFRA_SERVICES = []
     from gobapi.api import get_app
     app = get_app()
     assert(not app == None)

--- a/src/tests/test_infra.py
+++ b/src/tests/test_infra.py
@@ -1,0 +1,13 @@
+from gobapi.infra import start_all_services
+
+
+def test_start_all_services():
+    result = (
+        start_all_services(
+            ['exist', 'no_exist'],
+            factory=lambda x: x,
+            registry={'exist': lambda: 'foo'}
+        )
+    )
+    assert len(result) == 1
+    assert result[0] == 'foo'

--- a/src/tests/test_logger.py
+++ b/src/tests/test_logger.py
@@ -1,0 +1,16 @@
+import logging
+import os
+from unittest.mock import patch
+
+from gobcore.logging.logger import Logger
+from gobapi.logger import get_logger
+
+
+def test_run_test():
+     assert isinstance(get_logger('a'), logging.Logger)
+
+
+@patch("os.getenv")
+def test_run_prod(mock):
+    mock.return_value = 'PRODUCTION'
+    assert isinstance(get_logger("a"), Logger)

--- a/src/tests/test_services.py
+++ b/src/tests/test_services.py
@@ -31,6 +31,13 @@ class MockedService:
         self.running = False
 
 
+def test_create_teardown_adapter():
+    adapter = services._create_teardown_adapter(
+        lambda f, x, y: f(x+y), 4, 5
+    )
+    assert adapter(lambda x: x*2) == 18  # (4 + 5) * 2
+
+
 def test_signal_adapter():
     mock_signal = SignalMock()
     mock_func = mock.MagicMock()

--- a/src/tests/test_services.py
+++ b/src/tests/test_services.py
@@ -1,0 +1,74 @@
+from unittest import mock
+import signal as signallib
+
+from gobapi import services
+
+
+class SignalMock:
+    handler = None
+
+    def signal(self, signal, handler):
+        if signal == "foo":
+            raise ValueError()
+        self.handler = handler
+
+    def getsignal(self, signal):
+        return lambda s, f: None
+
+    def send(self, signal):
+        self.handler(signal, None)
+
+
+class MockedService:
+    running = True
+    name = "foo"
+
+    def start(self):
+        while self.running:
+            pass
+
+    def stop(self):
+        self.running = False
+
+
+def test_signal_adapter():
+    mock_signal = SignalMock()
+    mock_func = mock.MagicMock()
+    services._signal_adapter(mock_func, backend=mock_signal)
+    mock_signal.send(signallib.SIGINT)
+    mock_func.assert_called_once()
+    services._signal_adapter(1, backend=mock_signal, term_signal="foo")
+    assert mock_signal != 1
+
+
+def test_atexit_adapter():
+    mock_atexit = mock.MagicMock()
+    services._atexit_adapter(lambda: 1, backend=mock_atexit)
+    mock_atexit.register.assert_called_once()
+
+
+def test_threaded_service():
+    mock_service = MockedService()
+    mock_adapter = mock.MagicMock()
+
+    thread = services.threaded_service(
+        mock_service,
+        teardown_adapters=[mock_adapter]
+    )
+    # thread runs immediatly
+    assert thread.is_alive()
+    # and has the name of the service
+    assert thread.name == mock_service.name
+    mock_adapter.assert_called()
+    mock_adapter.call_args[0][0]()
+    # and is terminated after emitting term_signal
+    assert not thread.is_alive()
+
+
+def test_message_driven_service():
+    backend = mock.MagicMock()
+    service = services.MessageDrivenService(backend=backend)
+    service.start()
+    assert backend.messagedriven_service.called
+    service.stop()
+    assert backend.keep_running == False

--- a/src/tests/test_services.py
+++ b/src/tests/test_services.py
@@ -67,6 +67,8 @@ def test_threaded_service():
     # and has the name of the service
     assert thread.name == mock_service.name
     mock_adapter.assert_called()
+    # call_args[0][0] points to the teardown func passed to the adapter
+    # so run this, and the gthread should terminate.
     mock_adapter.call_args[0][0]()
     # and is terminated after emitting term_signal
     assert not thread.is_alive()

--- a/src/tests/test_services.py
+++ b/src/tests/test_services.py
@@ -76,7 +76,8 @@ def test_threaded_service():
 
 def test_message_driven_service():
     backend = mock.MagicMock()
-    service = services.MessageDrivenService(backend=backend)
+    services.MessageDrivenService.backend = backend  # inject dep
+    service = services.MessageDrivenService()
     service.start()
     assert backend.messagedriven_service.called
     service.stop()


### PR DESCRIPTION
Related issue: https://github.com/Amsterdam/GOB-API/issues/91

*Problem*: API service has no heartbeat at the moment

*Solution*: 
 * Added service orchestration in API application configurable with env `API_INFRA_SERVICES` (comma separated list of service references as defined in `services:registry`).
 * Added function to run services as thread.
 * Added a service implementation that starts/stops a `gobcore.message_broker.messagedriven_service`.
 * Added "start all" routines to both uwsgi and flask.run code paths.

*POW*:
![image](https://user-images.githubusercontent.com/287022/56962039-ce5b6880-6b55-11e9-962c-4afc88885e3d.png)
*`gob-management/status` API service recognised by heartbeat*