### PR TITLE
FIX: API tests will not start messagedriven service now

### DIFF
--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -95,6 +95,10 @@ def before_each_api_test(monkeypatch):
     import gobapi.response
     importlib.reload(gobapi.response)
 
+    import gobapi.api
+    importlib.reload(gobapi.config)
+    # override config so we isolate .run()
+
     global catalogs, catalog
     global collections, collection
     global entities, entity
@@ -106,6 +110,8 @@ def before_each_api_test(monkeypatch):
     entities = []
     entity = None
     view = None
+
+    monkeypatch.setattr(gobapi.config, 'API_INFRA_SERVICES', "")
 
     monkeypatch.setattr(flask, 'Flask', MockFlask)
     monkeypatch.setattr(flask_cors, 'CORS', MockCORS)
@@ -138,9 +144,6 @@ def before_each_api_test(monkeypatch):
 @patch("gobapi.services.threaded_service")
 def test_app(Mock, monkeypatch):
     before_each_api_test(monkeypatch)
-    import gobapi.api
-    # override config so we isolate .run()
-    gobapi.api.API_INFRA_SERVICES = []
     from gobapi.api import get_app
     app = get_app()
     assert(not app == None)

--- a/src/tests/test_services.py
+++ b/src/tests/test_services.py
@@ -79,6 +79,6 @@ def test_message_driven_service():
     services.MessageDrivenService.backend = backend  # inject dep
     service = services.MessageDrivenService()
     service.start()
-    assert backend.messagedriven_service.called
+    backend.messagedriven_service.assert_called()
     service.stop()
     assert backend.keep_running == False


### PR DESCRIPTION
*Solution*: reset config to empty on all api tests in `test_api.py`