### PR TITLE
Remove count on enhanced views

### DIFF
--- a/src/gobapi/api.py
+++ b/src/gobapi/api.py
@@ -101,7 +101,11 @@ def _entities(catalog_name, collection_name, page, page_size, view=None):
 
     entities, total_count = get_entities(catalog_name, collection_name, offset=offset, limit=page_size, view=view)
 
-    num_pages = (total_count + page_size - 1) // page_size
+    if view:
+        # For views always show next page unless no results are returned. Count is slow on large views
+        num_pages = page + 1 if len(entities) > 0 else page
+    else:
+        num_pages = (total_count + page_size - 1) // page_size
 
     return {
                'total_count': total_count,

--- a/src/gobapi/storage.py
+++ b/src/gobapi/storage.py
@@ -279,7 +279,8 @@ def get_entities(catalog, collection, offset, limit, view=None):
     else:
         all_entities = apply_filters(all_entities, filters)
 
-    all_count = all_entities.count()
+    # For views count is slow on large views
+    all_count = all_entities.count() if view is None else None
 
     # Limit and offset for pagination
     page_entities = all_entities.offset(offset).limit(limit).all()

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -196,7 +196,7 @@ def test_entities_with_view(monkeypatch):
 
     from gobapi.api import _entities
     collection = 'collection'
-    assert(_entities('catalog', 'collection', 1, 1, 'enhanced') == ({'page_size': 1, 'pages': 0, 'results': [], 'total_count': 0}, {'next': None, 'previous': None}))
+    assert(_entities('catalog', 'collection', 1, 1, 'enhanced') == ({'page_size': 1, 'pages': 1, 'results': [], 'total_count': 0}, {'next': None, 'previous': None}))
 
 
 def test_entity(monkeypatch):
@@ -311,10 +311,11 @@ def test_collection_with_view(monkeypatch):
     MockGOBViews.views = {
         'enhanced': {}
     }
+    # Views always show 1 page extra because count is slow on large views
     assert(_collection('catalog', 'collection') == (
         ({
              'page_size': 100,
-             'pages': 0,
+             'pages': 1,
              'results': [],
              'total_count': 0
          },{

--- a/src/tests/test_storage.py
+++ b/src/tests/test_storage.py
@@ -366,19 +366,20 @@ def test_entities_with_view(monkeypatch):
 
     from gobapi.storage import get_entities
     MockEntities.all_entities = []
-    assert(get_entities('catalog', 'collection1', 0, 1, 'enhanced') == ([], 0))
+    # Views return total_count None to prevent slow count on large tables
+    assert(get_entities('catalog', 'collection1', 0, 1, 'enhanced') == ([], None))
 
     mockEntity = MockEntity('identificatie', 'attribute', '_private_attribute')
     MockEntities.all_entities = [
         mockEntity
     ]
-    assert(get_entities('catalog', 'collection1', 0, 1, 'enhanced') == ([{'attribute': 'attribute', 'identificatie': 'identificatie'}], 1))
+    assert(get_entities('catalog', 'collection1', 0, 1, 'enhanced') == ([{'attribute': 'attribute', 'identificatie': 'identificatie'}], None))
 
     mockEntity = MockEntity('identificatie', 'attribute', 'non_existing_attribute')
     MockEntities.all_entities = [
         mockEntity
     ]
-    assert(get_entities('catalog', 'collection1', 0, 1, 'enhanced') == ([{'attribute': 'attribute', 'identificatie': 'identificatie'}], 1))
+    assert(get_entities('catalog', 'collection1', 0, 1, 'enhanced') == ([{'attribute': 'attribute', 'identificatie': 'identificatie'}], None))
 
     # Add a reference to the table columns
     MockTable.columns = [MockColumn('identificatie'), MockColumn('attribute'), MockColumn('_ref_is_test_tse_tst')]
@@ -387,7 +388,7 @@ def test_entities_with_view(monkeypatch):
     MockEntities.all_entities = [
         mockEntity
     ]
-    assert(get_entities('catalog', 'collection1', 0, 1, 'enhanced') == ([{'attribute': 'attribute', 'identificatie': 'identificatie', '_embedded': {'is_test': {FIELD.ID: '1234', '_links': {'self': {'href': '/gob/catalog/collection/1234/'}}}}}], 1))
+    assert(get_entities('catalog', 'collection1', 0, 1, 'enhanced') == ([{'attribute': 'attribute', 'identificatie': 'identificatie', '_embedded': {'is_test': {FIELD.ID: '1234', '_links': {'self': {'href': '/gob/catalog/collection/1234/'}}}}}], None))
 
     # Reset the table columns
     MockTable.columns = [MockColumn('identificatie'), MockColumn('attribute'), MockColumn('meta')]


### PR DESCRIPTION
Counts are slow on large database views so skip count when fetching rows. The number of pages is always one more than the current page, when results are returned, to allow for pagination