### PR TITLE
Fix bug in graphql resolver

### DIFF
--- a/src/gobapi/graphql/filters.py
+++ b/src/gobapi/graphql/filters.py
@@ -174,8 +174,7 @@ def get_resolve_attribute(model, src_attribute_name):
             bronwaardes = [bronwaardes]
 
         query = FilterConnectionField.get_query(model, info, **kwargs)
-
-        if obj.__has_states__:
+        if model.__has_states__:
             ids = _extract_tuples(bronwaardes, ('id', 'volgnummer'))
             query = query.filter(tuple_(getattr(model, FIELD.ID), getattr(model, FIELD.SEQNR)).in_(ids))
         else:

--- a/src/gobapi/storage.py
+++ b/src/gobapi/storage.py
@@ -168,7 +168,7 @@ def _get_convert_for_model(catalog, collection, model, meta={}, private_attribut
             hal_entity['_embedded'] = {k: _create_reference(entity, k, v, catalog, collection)
                                        for k, v in model['references'].items()
                                        if k not in model.get('very_many_references', {}).keys()
-                                       and (not k.startswith('_') and not v.get('hidden')) or private_attributes}
+                                       and ((not k.startswith('_') and not v.get('hidden')) or private_attributes)}
 
             # Delete embedded from the entity if no references are added
             if not hal_entity['_embedded']:

--- a/src/tests/graphql/test_filters.py
+++ b/src/tests/graphql/test_filters.py
@@ -200,6 +200,7 @@ class TestFilters(TestCase):
         class Model():
             _id = MagicMock()
             volgnummer = '2'
+            __has_states__ = False
 
         class Object():
             reference_field = {'bronwaarde': '1', '_id': '1', 'volgnummer': '2'}
@@ -232,6 +233,7 @@ class TestFilters(TestCase):
         class Model():
             _id = '1'
             volgnummer = '2'
+            __has_states__ = True
 
         class Object():
             reference_field = {'bronwaarde': '1', '_id': '1', 'volgnummer': '2'}


### PR DESCRIPTION
The relation resolver in graphql was testing if the object itself had states instead of the model it was querying for the relation. This commit fixes the issue.