### PR TITLE
Dump collection in csv-format

### DIFF
--- a/src/gobapi/api.py
+++ b/src/gobapi/api.py
@@ -159,6 +159,13 @@ def _reference_entities(src_catalog_name, src_collection_name, reference_name, s
 
 
 def _dump(catalog_name, collection_name):
+    """
+    Dump all entities in the requested format. Currently only csv
+
+    :param catalog_name:
+    :param collection_name:
+    :return: Streaming response of all entities in csv format with header
+    """
     format = request.args.get('format', "csv")
     assert format == "csv"
 

--- a/src/gobapi/api.py
+++ b/src/gobapi/api.py
@@ -18,8 +18,9 @@ from gobcore.views import GOBViews
 
 from gobapi.config import API_BASE_PATH
 from gobapi.response import hal_response, not_found, get_page_ref, ndjson_entities, stream_entities
+from gobapi.dump import csv_entities
 from gobapi.states import get_states
-from gobapi.storage import connect, get_entities, get_entity, query_entities, query_reference_entities
+from gobapi.storage import connect, get_entities, get_entity, query_entities, dump_entities, query_reference_entities
 
 from gobapi.graphql.schema import schema
 from gobapi.session import shutdown_session
@@ -155,6 +156,15 @@ def _reference_entities(src_catalog_name, src_collection_name, reference_name, s
                'next': get_page_ref(page + 1, num_pages),
                'previous': get_page_ref(page - 1, num_pages)
            }
+
+
+def _dump(catalog_name, collection_name):
+    format = request.args.get('format', "csv")
+    assert format == "csv"
+
+    entities, model = dump_entities(catalog_name, collection_name)
+
+    return Response(csv_entities(entities, model), mimetype='text/csv')
 
 
 def _collection(catalog_name, collection_name):
@@ -337,6 +347,7 @@ def get_app():
         (f'{API_BASE_PATH}/', _catalogs),
         (f'{API_BASE_PATH}/<catalog_name>/', _catalog),
         (f'{API_BASE_PATH}/<catalog_name>/<collection_name>/', _collection),
+        (f'{API_BASE_PATH}/dump/<catalog_name>/<collection_name>/', _dump),
         (f'{API_BASE_PATH}/<catalog_name>/<collection_name>/<entity_id>/', _entity),
         (f'{API_BASE_PATH}/<catalog_name>/<collection_name>/<entity_id>/<reference_path>/', _reference_collection),
 

--- a/src/gobapi/dump.py
+++ b/src/gobapi/dump.py
@@ -1,0 +1,97 @@
+from gobcore.typesystem import get_gob_type
+
+DELIMITER_CHAR = ";"
+QUOTATION_CHAR = '"'
+ESCAPE_CHAR = QUOTATION_CHAR
+
+SKIP_TYPES = ["GOB.VeryManyReference"]
+REFERENCE_TYPES = ["GOB.Reference", "GOB.ManyReference"]
+REFERENCE_FIELDS = ['ref', 'id', 'volgnummer', 'bronwaarde']
+
+HIDDEN_FIELDS = ["geometrie", "_hash", "_gobid", "_last_event"]
+
+
+def _names_join(*args):
+    return "_".join(args)
+
+
+def _add_ref(dst):
+    dst['ref'] = dst.get('id')
+    if dst.get('volgnummer') is not None:
+        dst['ref'] = _names_join(dst['ref'], dst['volgnummer'])
+
+
+def _csv_line(values):
+    return DELIMITER_CHAR.join(values) + "\n"
+
+
+def _csv_header(field_specs):
+    fields = []
+    for field_name, field_spec in field_specs.items():
+        if field_spec['type'] in REFERENCE_TYPES:
+            for reference_field in REFERENCE_FIELDS:
+                fields.append(_csv_value(_names_join(field_name, reference_field)))
+        else:
+            fields.append(_csv_value(field_name))
+    return fields
+
+
+def _csv_value(value):
+    if value is None:
+        return ""
+    elif isinstance(value, (int, float)):
+        return str(value)
+    else:
+        return f"{QUOTATION_CHAR}{value}{QUOTATION_CHAR}"
+
+
+def _csv_reference_values(value, spec):
+    values = []
+    if spec['type'] == "GOB.Reference":
+        dst = value or {}
+        _add_ref(dst)
+        for field in REFERENCE_FIELDS:
+            sub_value = dst.get(field, None)
+            values.append(_csv_value(sub_value))
+    else:  # GOB.ManyReference
+        dsts = value or []
+        for dst in dsts:
+            _add_ref(dst)
+        for field in REFERENCE_FIELDS:
+            sub_values = []
+            for dst in dsts:
+                sub_value = dst.get(field, None)
+                sub_values.append(_csv_value(sub_value))
+            values.append("[" + ",".join(sub_values) + "]")
+    return values
+
+
+def _csv_values(value, spec):  # noqa: C901
+    if spec['type'] in REFERENCE_TYPES:
+        return _csv_reference_values(value, spec)
+    else:
+        return [_csv_value(value)]
+
+
+def _csv_record(entity, field_specs):
+    fields = []
+    for field_name, field_spec in field_specs.items():
+        gob_type = get_gob_type(field_spec['type'])
+        entity_value = getattr(entity, field_name, None)
+        value = gob_type.from_value(entity_value).to_value
+        fields.extend(_csv_values(value, field_spec))
+    return fields
+
+
+def csv_entities(entities, model):
+    field_specs = model['all_fields']
+    field_specs = {k: v for k, v in field_specs.items() if k not in HIDDEN_FIELDS and v['type'] not in SKIP_TYPES}
+
+    header = _csv_header(field_specs)
+    for entity in entities:
+        if header:
+            fields = _csv_header(field_specs)
+            header = None
+        else:
+            fields = _csv_record(entity, field_specs)
+        yield _csv_line(fields)

--- a/src/gobapi/dump.py
+++ b/src/gobapi/dump.py
@@ -19,10 +19,20 @@ def _add_ref(dst):
     dst['ref'] = dst.get('id')
     if dst.get('volgnummer') is not None:
         dst['ref'] = _names_join(dst['ref'], dst['volgnummer'])
+    return dst
 
 
 def _csv_line(values):
     return DELIMITER_CHAR.join(values) + "\n"
+
+
+def _csv_value(value):
+    if value is None:
+        return ""
+    elif isinstance(value, (int, float)):
+        return str(value)
+    else:
+        return f"{QUOTATION_CHAR}{value}{QUOTATION_CHAR}"
 
 
 def _csv_header(field_specs):
@@ -34,15 +44,6 @@ def _csv_header(field_specs):
         else:
             fields.append(_csv_value(field_name))
     return fields
-
-
-def _csv_value(value):
-    if value is None:
-        return ""
-    elif isinstance(value, (int, float)):
-        return str(value)
-    else:
-        return f"{QUOTATION_CHAR}{value}{QUOTATION_CHAR}"
 
 
 def _csv_reference_values(value, spec):

--- a/src/gobapi/storage.py
+++ b/src/gobapi/storage.py
@@ -59,7 +59,7 @@ def _get_table_and_model(catalog_name, collection_name, view=None):
     """Table and Model
 
     Utility method to retrieve the Table and Model for a specific collection.
-    When a view is provided use the and do not retun the GOBModel.
+    When a view is provided use the and do not return the GOBModel.
 
     :param collection_name:
     :param view:
@@ -310,6 +310,15 @@ def get_entities(catalog, collection, offset, limit, view=None, reference_name=N
 
     entities = [entity_convert(entity) for entity in page_entities]
     return entities, all_count
+
+
+def dump_entities(catalog, collection):
+    assert _Base
+    session = get_session()
+
+    table, model = _get_table_and_model(catalog, collection)
+
+    return session.query(table), model
 
 
 def query_entities(catalog, collection, view):

--- a/src/gobapi/storage.py
+++ b/src/gobapi/storage.py
@@ -313,6 +313,13 @@ def get_entities(catalog, collection, offset, limit, view=None, reference_name=N
 
 
 def dump_entities(catalog, collection):
+    """
+    Get all entities in the given catalog collection
+
+    :param catalog:
+    :param collection:
+    :return: (all collection entities, the collection model)
+    """
     assert _Base
     session = get_session()
 

--- a/src/tests/test_dump.py
+++ b/src/tests/test_dump.py
@@ -1,0 +1,181 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from flask import Response
+
+from gobapi import dump, api, storage
+
+
+class MockEntity:
+
+    def __init__(self):
+        self.a = "a"
+        self.b = 5
+
+    @classmethod
+    def specs(self):
+        return {
+            'a': {
+                'type': 'GOB.String'
+            },
+            'b': {
+                'type': 'GOB.Integer'
+            }
+        }
+
+
+class MockSession:
+
+    def __init__(self):
+        pass
+
+    def query(self, any_query):
+        return any_query
+
+
+class TestDump(TestCase):
+
+    def test_names_join(self):
+        result = dump._names_join()
+        self.assertEqual(result, "")
+
+        result = dump._names_join("a")
+        self.assertEqual(result, "a")
+
+        result = dump._names_join("a", "b", "c")
+        self.assertEqual(result, "a_b_c")
+
+    def test_add_ref(self):
+        result = dump._add_ref({})
+        self.assertEqual(result, {'ref': None})
+
+        result = dump._add_ref({'any': 'value'})
+        self.assertEqual(result, {'any': 'value', 'ref': None})
+
+        result = dump._add_ref({'id': 'any id'})
+        self.assertEqual(result, {'id': 'any id', 'ref': 'any id'})
+
+        result = dump._add_ref({'id': 'any id', 'volgnummer': 'any volgnummer'})
+        self.assertEqual(result, {'id': 'any id', 'ref': 'any id_any volgnummer', 'volgnummer': 'any volgnummer'})
+
+    def test_csv_line(self):
+        result = dump._csv_line([])
+        self.assertEqual(result, "\n")
+
+        result = dump._csv_line(["a", "b"])
+        self.assertEqual(result, "a;b\n")
+
+    def test_csv_value(self):
+        result = dump._csv_value(None)
+        self.assertEqual(result, "")
+
+        result = dump._csv_value(0)
+        self.assertEqual(result, "0")
+
+        result = dump._csv_value(0.5)
+        self.assertEqual(result, "0.5")
+
+        result = dump._csv_value("s")
+        self.assertEqual(result, '"s"')
+
+        result = dump._csv_value({})
+        self.assertEqual(result, '"{}"')
+
+    def test_csv_header(self):
+        result = dump._csv_header({})
+        self.assertEqual(result, [])
+
+        result = dump._csv_header({'name': {'type': 'any type'}})
+        self.assertEqual(result, ['"name"'])
+
+        result = dump._csv_header({'name': {'type': 'GOB.Reference'}})
+        self.assertEqual(result, ['"name_ref"', '"name_id"', '"name_volgnummer"', '"name_bronwaarde"'])
+
+    def test_csv_reference_values(self):
+        spec = {'type': 'GOB.Reference'}
+        value = {}
+        result = dump._csv_reference_values(value, spec)
+        self.assertEqual(result, ['', '', '', ''])
+
+        value = {'id': 'any id', 'bronwaarde': 'any bronwaarde'}
+        result = dump._csv_reference_values(value, spec)
+        self.assertEqual(result, ['"any id"', '"any id"', '', '"any bronwaarde"'])
+
+        # defaults to ManyReference
+        spec = {'type': 'any type'}
+        values = []
+        result = dump._csv_reference_values(values, spec)
+        self.assertEqual(result, ['[]', '[]', '[]', '[]'])
+
+        spec = {'type': 'GOB.ManyReference'}
+        values = [value]
+        result = dump._csv_reference_values(values, spec)
+        self.assertEqual(result, ['["any id"]', '["any id"]', '[]', '["any bronwaarde"]'])
+
+        spec = {'type': 'GOB.ManyReference'}
+        values = [value, value]
+        result = dump._csv_reference_values(values, spec)
+        self.assertEqual(result, ['["any id","any id"]', '["any id","any id"]', '[,]', '["any bronwaarde","any bronwaarde"]'])
+
+    def test_csv_values(self):
+        value = None
+        result = dump._csv_values(None, {'type': 'any type'})
+        self.assertEqual(result, [dump._csv_value(value)])
+
+        value = {}
+        spec = {'type': 'GOB.Reference'}
+        result = dump._csv_values(value, spec)
+        self.assertEqual(result, dump._csv_reference_values(value, spec))
+
+    def test_csv_record(self):
+        entity = None
+        specs = {}
+        result = dump._csv_record(entity, specs)
+        self.assertEqual(result, [])
+
+        entity = MockEntity()
+        specs = entity.specs()
+
+        result = dump._csv_record(entity, specs)
+        self.assertEqual(result, ['"a"', '5'])
+
+    def test_csv_entities(self):
+        entities = []
+        model = {
+            'all_fields': {}
+        }
+        results = []
+        for result in dump.csv_entities(entities, model):
+            results.append(result)
+
+        self.assertEqual(results, [])
+
+        entities = [MockEntity(), MockEntity()]
+        model = {
+            'all_fields': MockEntity.specs()
+        }
+        results = []
+        for result in dump.csv_entities(entities, model):
+            results.append(result)
+
+        self.assertEqual(results, ['"a";"b"\n', '"a";5\n'])
+
+
+class TestDumpApi(TestCase):
+
+    @patch('gobapi.api.dump_entities', lambda cat, col: ([], {}))
+    @patch('gobapi.api.request')
+    def test_dump(self, mock_request):
+        mock_request.args = {'format': 'csv'}
+        result = api._dump("any catalog", "any collection")
+        self.assertIsInstance(result, Response)
+
+
+class TestDumpStorage(TestCase):
+
+    @patch('gobapi.storage._Base', "any base")
+    @patch('gobapi.storage.get_session', lambda: MockSession())
+    @patch('gobapi.storage._get_table_and_model', lambda cat, col: ("any table", "any model"))
+    def test_dump_entities(self):
+        result = storage.dump_entities("any catalog", "any collection")
+        self.assertEqual(result, ('any table', 'any model'))


### PR DESCRIPTION
A new endpoint has been created: .../dump/<catalog>/<collection>
A format specification is a required request argument
The collection entities are dumped to a csv-file