### PR TITLE
Remove duplicated export of very-many-references

### DIFF
--- a/src/gobapi/dump/to_db.py
+++ b/src/gobapi/dump/to_db.py
@@ -64,7 +64,7 @@ def dump_to_db(catalog_name, collection_name, config):
         yield from _dump_to_db(schema, catalog_name, collection_name, entities, model, config)
 
         # Then process all relations in the given collection
-        for relation in [k for k in model['references'].keys()] + [k for k in model['very_many_references'].keys()]:
+        for relation in [k for k in model['references'].keys()]:
             yield f"Export {catalog_name} {collection_name} {relation}\n"
 
             relation_name = get_relation_name(GOBModel(), catalog_name, collection_name, relation)

--- a/src/tests/test_dump.py
+++ b/src/tests/test_dump.py
@@ -558,7 +558,8 @@ class TestToDB(TestCase):
         }
         model = {
             'references': {
-                'ref': 'any ref'
+                'ref': 'any ref',
+                'vmref': 'any very many ref'
             },
             'very_many_references': {
                 'vmref': 'any very many ref'


### PR DESCRIPTION
model['references'] includes:
  'GOB.Reference',
  'GOB.ManyReference',
  'GOB.VeryManyReference'