### PR TITLE
Fix for truncated table names

### DIFF
--- a/src/gobapi/storage.py
+++ b/src/gobapi/storage.py
@@ -55,6 +55,22 @@ def connect():
     set_session(session)
 
 
+def _get_table(table_names, table_name):
+    """
+    Return the name of the table as it exists in the database.
+    The name can possibly be truncated, like in PostgreSQL to 63 characters
+
+    :param table_names:
+    :param table_name:
+    :return:
+    """
+    match = sorted([t for t in table_names if t == table_name[:len(t)]],
+                   key=lambda s: -len(s))[0]  # take longest match
+    if match != table_name:
+        print(f"Warning: table\n'{table_name}' is truncated to\n'{match}' in the database")
+    return match
+
+
 def _get_table_and_model(catalog_name, collection_name, view=None):
     """Table and Model
 
@@ -68,8 +84,8 @@ def _get_table_and_model(catalog_name, collection_name, view=None):
     if view:
         return Table(view, metadata, autoload=True), None
     else:
-        return getattr(_Base.classes, GOBModel().get_table_name(catalog_name, collection_name)), \
-                       GOBModel().get_collection(catalog_name, collection_name)
+        table_name = _get_table(dir(_Base.classes), GOBModel().get_table_name(catalog_name, collection_name))
+        return getattr(_Base.classes, table_name), GOBModel().get_collection(catalog_name, collection_name)
 
 
 def _create_reference_link(reference, catalog, collection):

--- a/src/tests/test_storage.py
+++ b/src/tests/test_storage.py
@@ -11,7 +11,7 @@ import sqlalchemy_filters
 
 from unittest import mock, TestCase
 
-from gobapi.storage import _get_convert_for_state, filter_deleted, connect, _format_reference
+from gobapi.storage import _get_convert_for_state, filter_deleted, connect, _format_reference, _get_table
 from gobcore.model.metadata import FIELD
 
 class MockEntity:
@@ -617,3 +617,14 @@ class TestStorage(TestCase):
                 }
             }
         }, res)
+
+    def test_get_table(self):
+        names = ["any"]
+        self.assertEqual(_get_table(names, names[0]), names[0])
+
+        names = ["any", "any1", "any123", "any", "any"]
+        for name in names:
+            self.assertEqual(_get_table(names, name), name)
+
+        names = ["any"]
+        self.assertEqual(_get_table(names, "any123"), "any")


### PR DESCRIPTION
Table names are truncated to 63 characters in PostgreSQL

rel_brk_zrt_brk_sjt_betrokken_bij_appartementsrechtsplitsing_vve
is 64 characters long and failed