### PR TITLE
Skip create indexes for references to (yet) non-existent tables

### DIFF
--- a/src/gobapi/dump/config.py
+++ b/src/gobapi/dump/config.py
@@ -26,6 +26,8 @@ REL_FIELDS = [f"src_{field}" for field in REL_INFO_FIELDS] +\
 SKIP_TYPES = ["GOB.VeryManyReference"]
 SKIP_FIELDS = ["_hash", "_gobid"]
 
+SKIP_RELATIONS = ["brk_tng_brk_sdl_is_gebaseerd_op_stukdeel"]
+
 # SQL constants
 SQL_TYPE_CONVERSIONS = {
     "GOB.String": "character varying",

--- a/src/gobapi/dump/to_db.py
+++ b/src/gobapi/dump/to_db.py
@@ -8,7 +8,7 @@ from gobapi.storage import dump_entities
 from gobcore.model import GOBModel
 from gobcore.model.relations import get_relation_name
 
-from gobapi.dump.config import get_field_specifications, get_reference_fields
+from gobapi.dump.config import get_field_specifications, get_reference_fields, SKIP_RELATIONS
 from gobapi.dump.sql import _create_schema, _create_table, _rename_table, _create_index
 from gobapi.dump.csv import csv_entities
 from gobapi.dump.csv_stream import CSVStream
@@ -113,9 +113,9 @@ def dump_to_db(catalog_name, collection_name, config):
         for relation in [k for k in model['references'].keys()]:
             relation_name = get_relation_name(GOBModel(), catalog_name, collection_name, relation)
 
-            if not relation_name:
+            if not relation_name or relation_name in SKIP_RELATIONS:
                 # relation_name is None when relation does not exist (yet)
-                yield f"Skipping unmapped {catalog_name} {collection_name} {relation}\n"
+                yield f"Skipping {catalog_name} {collection_name} {relation}\n"
                 continue
 
             yield f"Export {catalog_name} {collection_name} {relation}\n"

--- a/src/gobapi/dump/to_db.py
+++ b/src/gobapi/dump/to_db.py
@@ -8,7 +8,7 @@ from gobapi.storage import dump_entities
 from gobcore.model import GOBModel
 from gobcore.model.relations import get_relation_name
 
-from gobapi.dump.config import get_field_specifications
+from gobapi.dump.config import get_field_specifications, get_reference_fields
 from gobapi.dump.sql import _create_schema, _create_table, _rename_table, _create_index
 from gobapi.dump.csv import csv_entities
 from gobapi.dump.csv_stream import CSVStream
@@ -34,7 +34,7 @@ def _create_indexes(engine, schema, collection_name, model):
             indexes.append({'field': field})  # Plain entity id, full entity id (ref) or rel. foreign key (eg dst_ref)
         elif "GOB.Geo" in spec['type']:
             indexes.append({'field': field, 'method': "gist"})  # Spatial index
-        elif spec['type'] == "GOB.Reference":
+        elif spec['type'] == "GOB.Reference" and "ref" in get_reference_fields(spec):
             indexes.append({'field': f"{field}_ref"})           # Foreign key index
 
     for index in indexes:

--- a/src/tests/test_dump.py
+++ b/src/tests/test_dump.py
@@ -555,9 +555,10 @@ class MockStream():
 
 class TestToDB(TestCase):
 
+    @patch('gobapi.dump.to_db.SKIP_RELATIONS', ["skip me"])
     @patch('gobapi.dump.to_db.create_engine', MagicMock())
     @patch('gobapi.dump.to_db.URL', MagicMock())
-    @patch('gobapi.dump.to_db.get_relation_name', lambda *args: 'any relation name')
+    @patch('gobapi.dump.to_db.get_relation_name', lambda m, cat, col, rel: rel)
     @patch('gobapi.dump.to_db._dump_to_db')
     @patch('gobapi.dump.to_db.dump_entities')
     def test_dump(self, mock_entities, mock_dump):
@@ -567,7 +568,8 @@ class TestToDB(TestCase):
         model = {
             'references': {
                 'ref': 'any ref',
-                'vmref': 'any very many ref'
+                'vmref': 'any very many ref',
+                'skip me': 'skip this ref'
             },
             'very_many_references': {
                 'vmref': 'any very many ref'
@@ -604,7 +606,7 @@ class TestToDB(TestCase):
         mock_dump.return_value = iter([])
         results = [result for result in dump_to_db('any catalog name', 'any collection name', config)]
         self.assertEqual(mock_dump.call_count, 1)
-        self.assertEqual(2, len([line for line in results if line.startswith('Skipping unmapped')]))
+        self.assertEqual(2, len([line for line in results if line.startswith('Skipping')]))
 
     @patch('gobapi.dump.to_db._create_schema', MagicMock())
     @patch('gobapi.dump.to_db._create_indexes', MagicMock())


### PR DESCRIPTION
Also skip export of relation tables for specific tables.