### PR TITLE
Secure paths and args

### DIFF
--- a/src/gobapi/api.py
+++ b/src/gobapi/api.py
@@ -359,7 +359,7 @@ def _health():
     return 'Connectivity OK'
 
 
-def _add_route(app, rule, view_func, methods):
+def _add_route(app, paths, rule, view_func, methods):
     """
     For every rule add a public and a secure endpoint
 
@@ -377,7 +377,7 @@ def _add_route(app, rule, view_func, methods):
         API_BASE_PATH: public_route,
         API_SECURE_BASE_PATH: secure_route
     }
-    for path in [API_BASE_PATH, API_SECURE_BASE_PATH]:
+    for path in paths:
         wrapper = wrappers[path]
         wrapped_rule = f"{path}{rule}"
         app.add_url_rule(rule=wrapped_rule, methods=methods, view_func=wrapper(wrapped_rule, view_func))
@@ -408,19 +408,21 @@ def get_app():
     app.route(rule='/status/health/')(_health)
 
     # Application routes
+    PUBLIC = [API_BASE_PATH, API_SECURE_BASE_PATH]
+    # SECURE = [API_SECURE_BASE_PATH]
     ROUTES = [
-        ('/', _catalogs, ['GET']),
-        ('/<catalog_name>/', _catalog, ['GET']),
-        ('/<catalog_name>/<collection_name>/', _collection, ['GET']),
-        ('/<catalog_name>/<collection_name>/<entity_id>/', _entity, ['GET']),
-        ('/<catalog_name>/<collection_name>/<entity_id>/<reference_path>/', _reference_collection, ['GET']),
-        ('/toestanden/', _states, ['GET']),
-        ('/graphql/', graphql, ['GET', 'POST']),
-        ('/graphql/streaming/', graphql_streaming.entrypoint, ['POST']),
-        ('/dump/<catalog_name>/<collection_name>/', _dump, ['GET', 'POST'])
+        (PUBLIC, '/', _catalogs, ['GET']),
+        (PUBLIC, '/<catalog_name>/', _catalog, ['GET']),
+        (PUBLIC, '/<catalog_name>/<collection_name>/', _collection, ['GET']),
+        (PUBLIC, '/<catalog_name>/<collection_name>/<entity_id>/', _entity, ['GET']),
+        (PUBLIC, '/<catalog_name>/<collection_name>/<entity_id>/<reference_path>/', _reference_collection, ['GET']),
+        (PUBLIC, '/toestanden/', _states, ['GET']),
+        (PUBLIC, '/graphql/', graphql, ['GET', 'POST']),
+        (PUBLIC, '/graphql/streaming/', graphql_streaming.entrypoint, ['POST']),
+        (PUBLIC, '/dump/<catalog_name>/<collection_name>/', _dump, ['GET', 'POST'])
     ]
-    for rule, view_func, methods in ROUTES:
-        _add_route(app, rule, view_func, methods)
+    for paths, rule, view_func, methods in ROUTES:
+        _add_route(app, paths, rule, view_func, methods)
 
     app.teardown_appcontext(shutdown_session)
 

--- a/src/gobapi/auth/routes.py
+++ b/src/gobapi/auth/routes.py
@@ -5,6 +5,10 @@ from flask import request
 from gobcore.secure.config import AUTH_PATTERN, REQUEST_ROLES, REQUEST_USER
 from gobapi.auth.auth_query import Authority
 
+# Request args that require authorisation
+# SECURE_ARGS = ['view']  # view results are not checked for secure data!
+SECURE_ARGS = []
+
 
 def secure_route(rule, func):
     """
@@ -52,8 +56,8 @@ def _allows_access(rule, *args, **kwargs):
 
 
 def _allows_args():
-    # Check if a view parameter is present (view results are not checked for secure data!)
-    return request.args.get('view') is None
+    # Check if a secure parameter is present
+    return not [arg for arg in SECURE_ARGS if request.args.get(arg) is not None]
 
 
 def _issue_fraud_warning(rule, *args, **kwargs):

--- a/src/gobapi/auth/schemes.py
+++ b/src/gobapi/auth/schemes.py
@@ -1,6 +1,9 @@
 from gobcore.secure.config import GOB_ADMIN
 
 GOB_AUTH_SCHEME = {
+    "brk": {
+        "roles": [GOB_ADMIN]
+    },
     "test_catalogue": {
         "collections": {
             "secure": {

--- a/src/gobapi/auth/schemes.py
+++ b/src/gobapi/auth/schemes.py
@@ -1,9 +1,9 @@
 from gobcore.secure.config import GOB_ADMIN
 
 GOB_AUTH_SCHEME = {
-    "brk": {
-        "roles": [GOB_ADMIN]
-    },
+    # "brk": {
+    #     "roles": [GOB_ADMIN]
+    # },
     "test_catalogue": {
         "collections": {
             "secure": {

--- a/src/tests/auth/test_auth.py
+++ b/src/tests/auth/test_auth.py
@@ -36,6 +36,7 @@ class TestAuth(TestCase):
         result = wrapped_func()
         self.assertEqual(result, "Any result")
 
+    @patch('gobapi.auth.routes.SECURE_ARGS', ['secure_arg'])
     @patch('gobapi.auth.routes.Authority')
     @patch('gobapi.auth.routes.request')
     def test_public_route(self, mock_request, mock_authority_class):
@@ -53,7 +54,7 @@ class TestAuth(TestCase):
         self.assertEqual(result, "Any result")
 
         mock_request.headers = {}
-        mock_request.args = {'view': "any view"}
+        mock_request.args = {'secure_arg': "any secure_arg"}
         result = wrapped_func()
         self.assertEqual(result, (mock.ANY, 403))
 

--- a/src/tests/auth/test_auth_query.py
+++ b/src/tests/auth/test_auth_query.py
@@ -19,6 +19,16 @@ mock_scheme = {
             }
         }
     },
+    "secure catalog": {
+        "roles": [role_a, role_b]
+    },
+    "secure catalog collection": {
+        "collections": {
+            "secure collection": {
+                "roles": [role_a, role_b]
+            }
+        }
+    },
 }
 
 class MockEntity():
@@ -138,3 +148,25 @@ class TestAuthority(TestCase):
         result = authority.get_secured_value(mock_secure_type)
         mock_user.assert_called_with(mock_request)
         mock_secure_type.get_value.assert_called_with("any user")
+
+    @patch("gobapi.auth.auth_query.request", mock_request)
+    @patch("gobapi.auth.auth_query.GOB_AUTH_SCHEME", mock_scheme)
+    def test_allows_access(self):
+        authority = Authority('secure catalog', 'any col')
+        authority.get_roles = lambda : []
+        self.assertFalse(authority.allows_access())
+
+        authority.get_roles = lambda : [role_b]
+        self.assertTrue(authority.allows_access())
+
+        authority._catalog = "secure catalog collection"
+        authority._collection = "secure collection"
+        authority.get_roles = lambda : []
+        self.assertFalse(authority.allows_access())
+
+        authority.get_roles = lambda : [role_b]
+        self.assertTrue(authority.allows_access())
+
+        authority._collection = "any collection"
+        authority.get_roles = lambda : []
+        self.assertTrue(authority.allows_access())


### PR DESCRIPTION
Preparation for secure paths and secure args

BRK will eventually be a secure path
A request with a view argument will also be considered secure

For now these changes have been commented out but the functionality is available and tested.

It should be activated when security has been configured in Openstack