### PR TITLE
[GOB-1340] Fix relation joins on REST API

### DIFF
--- a/src/gobapi/storage.py
+++ b/src/gobapi/storage.py
@@ -499,14 +499,16 @@ def _add_relation_joins(catalog, collection, table, query):
             relation_join_args.append(getattr(table, FIELD.SEQNR) == getattr(relation_model, 'src_volgnummer'))
 
         # Join all relation tables and create a array of all relations. Include source value to match the objects
-        query = query.join(relation_model, and_(*relation_join_args)) \
+        query = query.outerjoin(relation_model, and_(*relation_join_args)) \
                      .add_columns(
                         func.json_agg(func.json_build_object(
                             FIELD.SOURCE_VALUE, getattr(relation_model, FIELD.SOURCE_VALUE),
                             API_FIELD.START_VALIDITY_RELATION, getattr(relation_model, FIELD.START_VALIDITY),
                             API_FIELD.END_VALIDITY_RELATION, getattr(relation_model, FIELD.END_VALIDITY)))
-                        .label(relation_name)) \
-                     .group_by(table)
+                        .label(relation_name))
+
+    # Add group by clause to aggregate relation results
+    query = query.group_by(table)
 
     return query
 

--- a/src/tests/test_storage.py
+++ b/src/tests/test_storage.py
@@ -117,6 +117,9 @@ class MockEntities:
     def join(self, *args):
         return self
 
+    def outerjoin(self, *args):
+        return self
+
     def yield_per(self, *args):
         return self
 
@@ -887,8 +890,8 @@ class TestStorage(TestCase):
 
         mock_relation_model = mock_models['rel_relation_name']
 
-        mock_query.join.assert_called_with(mock_relation_model, mock_and.return_value)
-        join_res = mock_query.join.return_value
+        mock_query.outerjoin.assert_called_with(mock_relation_model, mock_and.return_value)
+        join_res = mock_query.outerjoin.return_value
 
         join_res.add_columns.assert_called()
         add_columns_res = join_res.add_columns.return_value


### PR DESCRIPTION
Joining relations on the REST API was being done with an inner join instead of an outer join, resulting in fewer records than expected. Group by clause was moved out of the loop to prevent duplication