### PR TITLE
Fix error in SQL type conversions

### DIFF
--- a/src/gobapi/dump/config.py
+++ b/src/gobapi/dump/config.py
@@ -44,8 +44,8 @@ SQL_TYPE_CONVERSIONS = {
 }
 # Add constants for secure types (match on their base type)
 for t in GOB_SECURE_TYPES:
-    name = t.name
-    SQL_TYPE_CONVERSIONS[name] = SQL_TYPE_CONVERSIONS[f"GOB.{name.replace('Secure', '')}"]
+    # Type conversion GOB.Secure<<type>> = type conversion GOB.<<type>>
+    SQL_TYPE_CONVERSIONS[f"GOB.{t.name}"] = SQL_TYPE_CONVERSIONS[f"GOB.{t.name.replace('Secure', '')}"]
 
 SQL_QUOTATION_MARK = "'"
 

--- a/src/gobapi/dump/to_db.py
+++ b/src/gobapi/dump/to_db.py
@@ -1,4 +1,5 @@
 import re
+import traceback
 
 from sqlalchemy import create_engine
 from sqlalchemy.engine.url import URL
@@ -263,4 +264,5 @@ def dump_to_db(catalog_name, collection_name, config):
 
         yield "Export completed\n"
     except Exception as e:
-        yield f"ERROR: Export failed - {str(e)}\n"
+        print("Dump failed", traceback.format_exc(limit=-5))
+        yield f"ERROR: Dump failed - {str(e)}\n"

--- a/src/tests/dump/test_to_db.py
+++ b/src/tests/dump/test_to_db.py
@@ -458,4 +458,4 @@ class TestModuleFunctions(TestCase):
         mock_dumper.side_effect = Exception
 
         result = "".join(list(dump_to_db('catalog_name', 'collection_name', {})))
-        self.assertIn("ERROR: Export failed", result)
+        self.assertIn("ERROR: Dump failed", result)


### PR DESCRIPTION
Type conversion GOB.Secure<<type>> = type conversion GOB.<<type>>

Add extra traceback info to log in case dump fails