### PR TITLE
Fix voor JSON's that do not contain secure attributes

### DIFF
--- a/src/gobapi/auth/auth_query.py
+++ b/src/gobapi/auth/auth_query.py
@@ -92,7 +92,7 @@ class Authority():
         gob_type = get_gob_type_from_info(spec)
         if issubclass(gob_type, gob_secure_types.Secure):
             return True
-        elif issubclass(get_gob_type_from_info(spec), gob_types.JSON):
+        elif issubclass(gob_type, gob_types.JSON):
             return any([self._is_secure_type(attr) for attr in spec['attributes'].values()])
 
     def get_secured_columns(self):

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -25,7 +25,7 @@ more-itertools==4.3.0
 pika==0.12.0
 pluggy==0.7.1
 promise==2.2.1
-psycopg2-binary==2.7.5
+psycopg2-binary==2.7.7
 py==1.6.0
 pycodestyle==2.3.1
 pyflakes==1.6.0

--- a/src/tests/auth/test_auth_query.py
+++ b/src/tests/auth/test_auth_query.py
@@ -1,7 +1,7 @@
 from unittest import TestCase, mock
 from unittest.mock import patch, MagicMock
 
-from gobapi.auth.auth_query import Authority, AuthorizedQuery, GOB_AUTH_SCHEME, REQUEST_ROLES, gob_types
+from gobapi.auth.auth_query import Authority, AuthorizedQuery, GOB_AUTH_SCHEME, REQUEST_ROLES, gob_types, gob_secure_types
 
 role_a = "a"
 role_b = "b"
@@ -214,10 +214,8 @@ class TestAuthority(TestCase):
         authority.get_roles = lambda : []
         self.assertTrue(authority.allows_access())
 
-
     @patch("gobapi.auth.auth_query.GOBModel")
-    @patch("gobapi.auth.auth_query.GOB_SECURE_TYPES", ['secure type'])
-    @patch("gobapi.auth.auth_query.get_gob_type_from_info", lambda spec: 'secure type')
+    @patch("gobapi.auth.auth_query.get_gob_type_from_info", lambda spec: gob_secure_types.SecureString)
     def test_get_secured_columns(self, mock_model):
         mock_model.return_value.get_collection.return_value = {
             'fields': {
@@ -226,20 +224,84 @@ class TestAuthority(TestCase):
         }
         authority = Authority('secure catalog', 'any col')
         secure_columns = authority.get_secured_columns()
-        self.assertEqual(secure_columns, {'secure column': {'gob_type': 'secure type', 'spec': 'any spec'}})
+        self.assertEqual(secure_columns, {'secure column': {'gob_type': gob_secure_types.SecureString, 'spec': 'any spec'}})
 
     @patch("gobapi.auth.auth_query.GOBModel")
-    @patch("gobapi.auth.auth_query.GOB_SECURE_TYPES", ['secure type'])
-    @patch("gobapi.auth.auth_query.get_gob_type_from_info", lambda spec: gob_types.JSON)
     def test_get_secured_json_columns(self, mock_model):
         mock_model.return_value.get_collection.return_value = {
             'fields': {
-                'secure column': 'any spec'
+                'secure column': {
+                    'type': 'GOB.JSON',
+                    'attributes': {
+                        'attr1': {
+                            'type': 'GOB.SecureString'
+                        },
+                        'attr2': {
+                            'type': 'GOB.String'
+                        }
+                    }
+                }
             }
         }
         authority = Authority('secure catalog', 'any col')
         secure_columns = authority.get_secured_columns()
-        self.assertEqual(secure_columns, {'secure column': {'gob_type': gob_types.JSON, 'spec': 'any spec'}})
+        expect = {
+            'secure column': {
+                'gob_type': gob_types.JSON,
+                'spec': {
+                    'type': 'GOB.JSON',
+                    'gob_type': gob_types.JSON,
+                    'attributes': {
+                        'attr1': {
+                            'type': 'GOB.SecureString',
+                            'gob_type': gob_secure_types.SecureString
+                        },
+                        'attr2': {
+                            'type': 'GOB.String',
+                            'gob_type': gob_types.String
+                        }
+                    },
+                }
+            }
+        }
+        print(secure_columns)
+        self.assertEqual(secure_columns, expect)
+
+    def test_is_secure_type(self):
+        authority = Authority('secure catalog', 'any col')
+
+        spec = {
+            "type": "GOB.String"
+        }
+        self.assertFalse(authority._is_secure_type(spec))
+
+        spec = {
+            "type": "GOB.SecureString"
+        }
+        self.assertTrue(authority._is_secure_type(spec))
+
+        spec = {
+            "type": "GOB.JSON",
+            "attributes": {
+                "attr": {
+                    "type": "GOB.String"
+                }
+            }
+        }
+        self.assertFalse(authority._is_secure_type(spec))
+
+        spec = {
+            "type": "GOB.JSON",
+            "attributes": {
+                "attr": {
+                    "type": "GOB.String"
+                },
+                "attr": {
+                    "type": "GOB.SecureString"
+                }
+            }
+        }
+        self.assertTrue(authority._is_secure_type(spec))
 
     def test_handle_secured_columns(self):
         authority = Authority('secure catalog', 'any col')


### PR DESCRIPTION
Needed to prevent errors in exports that are based on enhanced views.

Example: failure of BAG brondocumenten export