### PR TITLE
Release Improve dump by comparing counts

### DIFF
--- a/src/gobapi/dump/sql.py
+++ b/src/gobapi/dump/sql.py
@@ -154,6 +154,18 @@ def delete_entities_with_source_ids(schema, collection_name, source_ids):
     return f"DELETE FROM {table_name} WHERE {FIELD.SOURCE_ID} IN ({source_ids_sql})"
 
 
+def get_count(schema, collection_name):
+    """
+    Returns the SQL statement that returns the number of rows in the given table (schema.collection)
+
+    :param schema:
+    :param collection_name:
+    :return:
+    """
+    table_name = _quoted_tablename(schema, collection_name)
+    return f"SELECT count(*) FROM {table_name}"
+
+
 def _autorized_order(order, catalog_name, collection_name):
     """
     Filter the order (list of columns) on columns that are not suppressed given the current request

--- a/src/gobapi/storage.py
+++ b/src/gobapi/storage.py
@@ -545,6 +545,24 @@ def get_entity_refs_after(catalog: str, collection: str, last_eventid: int) -> L
     return [row[0] for row in query.all()]
 
 
+def get_count(catalog: str, collection: str) -> int:
+    """
+    Returns the number of entities present in the object table for given catalog and collection
+
+    :param catalog:
+    :param collection:
+    :return:
+    """
+    assert _Base
+    session = get_session()
+
+    table, _ = get_table_and_model(catalog, collection)
+
+    query = session.query(table)
+    query.set_catalog_collection(catalog, collection)
+    return query.count()
+
+
 def get_max_eventid(catalog: str, collection: str) -> int:
     """Returns max eventid present in the object table for given catalog and collection
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -12,7 +12,7 @@ Flask-SQLAlchemy==2.3.2
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
 -e git+https://github.com/Amsterdam/flask-audit-log.git@v0.1.0a-rc1#egg=flask-audit-log
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.15.9c#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.16.0#egg=gobcore
 graphene==2.1.3
 graphene-sqlalchemy==2.1.0
 graphql-core==2.1

--- a/src/tests/dump/test_sql.py
+++ b/src/tests/dump/test_sql.py
@@ -2,7 +2,8 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from gobapi.dump.sql import _create_table, _create_schema, _import_csv, sql_entities, get_max_eventid, \
-    delete_entities_with_source_ids, _quoted_tablename, _rename_table, _delete_table, _create_indexes, _create_index, to_sql_string_value
+    delete_entities_with_source_ids, _quoted_tablename, _rename_table, _delete_table, _create_indexes, _create_index, to_sql_string_value, \
+    get_count
 from gobapi.dump.config import REFERENCE_FIELDS
 
 
@@ -139,6 +140,10 @@ class TestSQL(TestCase):
     def test_get_max_eventid(self):
         result = get_max_eventid('schema', 'collection')
         self.assertEqual('SELECT max(_last_event) FROM "schema"."collection"', result)
+
+    def test_get_count(self):
+        result = get_count('schema', 'collection')
+        self.assertEqual('SELECT count(*) FROM "schema"."collection"', result)
 
     def test_delete_entities_with_source_ids(self):
         result = delete_entities_with_source_ids('schema', 'collection', ['source_id_a', 'source_id_b'])

--- a/src/tests/test_storage.py
+++ b/src/tests/test_storage.py
@@ -15,7 +15,7 @@ from gobapi.storage import _get_convert_for_state, filter_deleted, connect, _for
     _to_gob_value, _add_resolve_attrs_to_columns, _get_convert_for_table, _add_relation_dates_to_manyreference, \
     _flatten_join_result, get_entity_refs_after, dump_entities, get_max_eventid, exec_statement, \
     _create_reference_link, _create_reference_view, _create_reference, _add_relations, _apply_filters, \
-    get_id_columns, clear_test_dbs
+    get_id_columns, clear_test_dbs, get_count
 from gobapi.auth.auth_query import AuthorizedQuery
 from gobcore.model import GOBModel
 from gobcore.model.metadata import FIELD
@@ -923,6 +923,22 @@ class TestStorage(TestCase):
 
         # Scalar value is returned
         self.assertEqual(mock_get_session.return_value.query.return_value.scalar.return_value, result)
+
+    @mock.patch("gobapi.storage._Base", mock.MagicMock())
+    @mock.patch("gobapi.storage.get_table_and_model")
+    @mock.patch("gobapi.storage.get_session")
+    def test_get_count(self, mock_get_session, mock_get_table_and_model):
+        table = type('MockTable', (object,), {'_last_event': 82404})
+
+        mock_get_table_and_model.return_value = table, 'model'
+
+        result = get_count('catalog', 'collection')
+        mock_get_table_and_model.assert_called_with('catalog', 'collection')
+
+        mock_get_session.return_value.query.assert_called_with(table)
+
+        # Scalar value is returned
+        self.assertEqual(mock_get_session.return_value.query.return_value.count.return_value, result)
 
     @mock.patch("gobapi.storage._Base", mock.MagicMock())
     @mock.patch("gobapi.storage.get_table_and_model")


### PR DESCRIPTION
Use an extra check to assure that the number of rows in the source
and destination database match.