### PR TITLE
PGB-1329 Only export bronwaarde as column for relations in dump to an…

### DIFF
--- a/src/gobapi/dump/config.py
+++ b/src/gobapi/dump/config.py
@@ -1,5 +1,4 @@
 from gobcore.typesystem import get_gob_type, GOB_SECURE_TYPES
-from gobcore.model import GOBModel
 from gobcore.model.metadata import FIELD
 from gobcore.typesystem import is_gob_geo_type, is_gob_reference_type
 
@@ -13,7 +12,7 @@ SIMPLE_ID = 'id'
 UNIQUE_ID = 'ref'
 UNIQUE_REL_ID = "CONCAT(src_ref, '_', dst_ref)"
 REFERENCE_TYPES = ["GOB.Reference", "GOB.ManyReference"]
-REFERENCE_FIELDS = [UNIQUE_ID, SIMPLE_ID, FIELD.SEQNR, FIELD.SOURCE_VALUE]
+REFERENCE_FIELDS = [FIELD.SOURCE_VALUE]
 
 # Relation fields, basically src_ref, src_id, src_volgnummer, dst_ref, dst_id, dst_volgnummer and expiration date
 REL_INFO_FIELDS = [UNIQUE_ID, "id", FIELD.SEQNR]
@@ -75,22 +74,13 @@ def get_reference_fields(spec):
     """
     Get the reference fields for a given referenced (spec)
 
-    If the reference refers to an entity without states then do not include volgnummer
+    NB: This method used to contain logic to return different fields for different references (such as id and seqnr),
+    but these fields are no longer used. All REFERENCE_FIELDS are now returned by default.
 
-    For references without an existing destination relation, only include bronwaarde
     :param spec: type specification
     :return: array with reference fields
     """
-    catalog_name, collection_name = spec['ref'].split(':')
-
-    if GOBModel().get_collection(catalog_name, collection_name) is None:
-        # Relation does not exist yet, only use SOURCE_VALUE
-        return [FIELD.SOURCE_VALUE]
-
-    if GOBModel().has_states(catalog_name, collection_name):
-        return REFERENCE_FIELDS
-    else:
-        return [rf for rf in REFERENCE_FIELDS if rf != FIELD.SEQNR]
+    return REFERENCE_FIELDS
 
 
 def get_unique_reference(entity, field_name, specs):

--- a/src/tests/dump/test_config.py
+++ b/src/tests/dump/test_config.py
@@ -45,29 +45,9 @@ class MockSession:
         return "any table"
 
 
-class MockModel:
-    cat_col_has_states = None
-    collection = {'cat': 'col'}
-
-    def has_states(self, cat, col):
-        return self.cat_col_has_states
-
-    def get_collection(self, cat, col):
-        return self.collection
-
-
 class TestConfig(TestCase):
 
-    @patch('gobapi.dump.config.GOBModel', MockModel)
     def test_reference_fields(self):
-        MockModel.cat_col_has_states = True
-        self.assertEqual(get_reference_fields({'ref': 'a:b'}), REFERENCE_FIELDS)
-        self.assertTrue(FIELD.SEQNR in get_reference_fields({'ref': 'a:b'}))
-
-        MockModel.cat_col_has_states = False
-        self.assertTrue(FIELD.SEQNR not in get_reference_fields({'ref': 'a:b'}))
-
-        MockModel.collection = None
         self.assertEqual([FIELD.SOURCE_VALUE], get_reference_fields({'ref': 'a:b'}))
 
     def test_joined_names(self):

--- a/src/tests/dump/test_csv.py
+++ b/src/tests/dump/test_csv.py
@@ -64,7 +64,7 @@ class TestCSV(TestCase):
         self.assertEqual(result, ['"name"'])
 
         result = _csv_header({'name': {'type': 'GOB.Reference'}}, ['name'])
-        self.assertEqual(result, ['"name_ref"', '"name_id"', '"name_volgnummer"', '"name_bronwaarde"'])
+        self.assertEqual(result, ['"name_bronwaarde"'])
 
         result = _csv_header({'name': {'type': 'GOB.JSON', 'attributes': {'a': 'some a', 'b': 'some b'}}}, ['name'])
         self.assertEqual(result, ['"name_a"', '"name_b"'])
@@ -74,27 +74,27 @@ class TestCSV(TestCase):
         spec = {'type': 'GOB.Reference'}
         value = {}
         result = _csv_reference_values(value, spec)
-        self.assertEqual(result, ['', '', '', ''])
+        self.assertEqual(result, [''])
 
         value = {'id': 'any id', 'bronwaarde': 'any bronwaarde'}
         result = _csv_reference_values(value, spec)
-        self.assertEqual(result, ['"any id"', '"any id"', '', '"any bronwaarde"'])
+        self.assertEqual(result, ['"any bronwaarde"'])
 
         # defaults to ManyReference
         spec = {'type': 'any type'}
         values = []
         result = _csv_reference_values(values, spec)
-        self.assertEqual(result, ['[]', '[]', '[]', '[]'])
+        self.assertEqual(result, ['[]'])
 
         spec = {'type': 'GOB.ManyReference'}
         values = [value]
         result = _csv_reference_values(values, spec)
-        self.assertEqual(result, ['["any id"]', '["any id"]', '[]', '["any bronwaarde"]'])
+        self.assertEqual(result, ['["any bronwaarde"]'])
 
         spec = {'type': 'GOB.ManyReference'}
         values = [value, value]
         result = _csv_reference_values(values, spec)
-        self.assertEqual(result, ['["any id","any id"]', '["any id","any id"]', '[,]', '["any bronwaarde","any bronwaarde"]'])
+        self.assertEqual(result, ['["any bronwaarde","any bronwaarde"]'])
 
     @patch('gobapi.dump.csv.get_reference_fields', lambda x: REFERENCE_FIELDS)
     def test_csv_values(self):

--- a/src/tests/dump/test_sql.py
+++ b/src/tests/dump/test_sql.py
@@ -45,7 +45,7 @@ class TestSQL(TestCase):
             }
         }
         result = _create_table(catalogue, 'any_schema', 'any_table', {})
-        for s in ['ref', 'id', 'volgnummer', 'bronwaarde']:
+        for s in ['bronwaarde']:
             self.assertTrue(f"\"a_{s}\"" in result)
             self.assertTrue(f"character varying" in result)
 


### PR DESCRIPTION
…alyse db. No longer export ref, id and volgnummer columns as relate no longer sets these values