### PR TITLE
Truncate table before copying tmp table

### DIFF
--- a/src/gobapi/dump/sql.py
+++ b/src/gobapi/dump/sql.py
@@ -96,20 +96,20 @@ def _delete_table(schema, name):
     return f"DROP TABLE IF EXISTS {table} CASCADE"
 
 
-def _rename_table(schema, current_name, new_name):
+def _insert_into_table(schema, src_name, dst_name):
     """
-    Rename table with the given current_name in the given schema to new_name in the same schema
+    Truncates the dst_table and copy the data from src_table in the given schema to dst_name in the same schema
 
     :param schema:
-    :param current_name:
-    :param new_name:
+    :param src_name:
+    :param dst_name:
     :return:
     """
-    current_table = _quoted_tablename(schema, current_name)
-    new_table = _quoted_tablename(schema, new_name)
+    src_table = _quoted_tablename(schema, src_name)
+    dst_table = _quoted_tablename(schema, dst_name)
     return f"""
-DROP  TABLE IF EXISTS {new_table}     CASCADE;
-ALTER TABLE IF EXISTS {current_table} RENAME TO {new_name}
+TRUNCATE TABLE {dst_table};
+INSERT INTO {dst_table} SELECT * FROM {src_table}
 """
 
 
@@ -218,8 +218,6 @@ def _create_table(schema, catalog_name, collection_name, model):
     primary_key = f",PRIMARY KEY ({UNIQUE_ID})" if UNIQUE_ID in order else ""
 
     return f"""
-DROP TABLE IF EXISTS {table_name} CASCADE;
--- TRUNCATE TABLE {table_name};
 CREATE TABLE IF NOT EXISTS {table_name}
 (
   {table_fields}

--- a/src/tests/dump/test_sql.py
+++ b/src/tests/dump/test_sql.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from gobapi.dump.sql import _create_table, _create_schema, _import_csv, sql_entities, get_max_eventid, \
-    delete_entities_with_source_ids, _quoted_tablename, _rename_table, _delete_table, _create_indexes, _create_index, to_sql_string_value, \
+    delete_entities_with_source_ids, _quoted_tablename, _insert_into_table, _delete_table, _create_indexes, _create_index, to_sql_string_value, \
     get_count
 from gobapi.dump.config import REFERENCE_FIELDS
 
@@ -90,10 +90,10 @@ class TestSQL(TestCase):
         self.assertEqual('DROP TABLE IF EXISTS "any schema"."any name" CASCADE',
                          result)
 
-    def test_rename_table(self):
-        result = _rename_table('schema', 'current_name', 'new_name')
-        self.assertEqual('\nDROP  TABLE IF EXISTS "schema"."new_name"     CASCADE;\n'
-                         'ALTER TABLE IF EXISTS "schema"."current_name" RENAME TO new_name\n',
+    def test_insert_into_table(self):
+        result = _insert_into_table('schema', 'current_name', 'new_name')
+        self.assertEqual('\nTRUNCATE TABLE "schema"."new_name";\n'
+                         'INSERT INTO "schema"."new_name" SELECT * FROM "schema"."current_name"\n',
                          result)
 
     @patch('gobapi.dump.sql.get_reference_fields')

--- a/src/tests/dump/test_to_db.py
+++ b/src/tests/dump/test_to_db.py
@@ -194,16 +194,19 @@ class TestDbDumper(TestCase):
             db_dumper.model,
         )
 
-    @patch("gobapi.dump.to_db._rename_table")
-    def test_rename_tmp_table(self, mock_rename, mock_datastore_factory):
+    @patch("gobapi.dump.to_db._insert_into_table")
+    def test_copy_tmp_table(self, mock_copy, mock_datastore_factory):
         db_dumper = self._get_dumper()
         db_dumper._execute = MagicMock()
-        list(db_dumper._rename_tmp_table())
+        db_dumper._delete_tmp_table = MagicMock()
+        list(db_dumper._copy_tmp_table())
 
-        mock_rename.assert_called_with(db_dumper.schema,
-                                       current_name=db_dumper.tmp_collection_name,
-                                       new_name=db_dumper.collection_name)
-        db_dumper._execute.assert_called_with(mock_rename.return_value)
+        mock_copy.assert_called_with(db_dumper.schema,
+                                       src_name=db_dumper.tmp_collection_name,
+                                       dst_name=db_dumper.collection_name)
+        db_dumper._execute.assert_called_with(mock_copy.return_value)
+        
+        db_dumper._delete_tmp_table.assert_called()
 
     @patch("gobapi.dump.to_db._delete_table")
     def test_delete_tmp_table(self, mock_delete, mock_datastore_factory):
@@ -294,7 +297,7 @@ class TestDbDumper(TestCase):
         db_dumper = self._get_dumper()
         db_dumper._prepare_destination = MagicMock(return_value="")
         db_dumper._dump_entities_to_table = MagicMock(return_value="")
-        db_dumper._rename_tmp_table = MagicMock(return_value="")
+        db_dumper._copy_tmp_table = MagicMock(return_value="")
         db_dumper._create_indexes = MagicMock(return_value="")
         db_dumper._copy_table_into = MagicMock()
         db_dumper._delete_dst_entities = MagicMock()
@@ -630,7 +633,7 @@ left join (
             db_dumper._full_dump = MagicMock(side_effect=mock_dump)
             db_dumper._sync_dump = MagicMock(side_effect=mock_dump)
             db_dumper._dump_entities_to_table = MagicMock()
-            db_dumper._rename_tmp_table = MagicMock()
+            db_dumper._copy_tmp_table = MagicMock()
             db_dumper._create_indexes = MagicMock()
 
         db_dumper = DbDumper('catalog', 'collection', {'db': {}})


### PR DESCRIPTION
Dropping the table caused the view to be cascaded as well. Truncating and then inserting the data into the tables fixes the issue