### PR TITLE
Add tablename kwarg to create_table function in dump functionality.

### DIFF
--- a/src/gobapi/dump/sql.py
+++ b/src/gobapi/dump/sql.py
@@ -175,7 +175,7 @@ def _autorized_order(order, catalog_name, collection_name):
     return [o for o in order if o not in suppress_columns]
 
 
-def _create_table(schema, catalog_name, collection_name, model):
+def _create_table(schema, catalog_name, collection_name, model, tablename=None):
     """
     Returns a SQL statement to create a table in a schema
     The table fields are constructed from the specs
@@ -183,6 +183,7 @@ def _create_table(schema, catalog_name, collection_name, model):
     :param schema:
     :param collection_name:
     :param specs:
+    :param tablename: if None, collection_name is used
     :return:
     """
     specs = get_field_specifications(model)
@@ -207,7 +208,7 @@ def _create_table(schema, catalog_name, collection_name, model):
     field_lengths = [len(field['name']) for field in fields]
     max_length = max(field_lengths) if field_lengths else 1
 
-    table_name = (f"{_quote(schema)}.{_quote(collection_name)}")
+    table_name = (f"{_quote(schema)}.{_quote(tablename or collection_name)}")
     table_fields = ",\n  ".join([f"{field['name']:{max_length}} {field['type']}" for field in fields])
 
     comments = ";\n".join([

--- a/src/gobapi/dump/to_db.py
+++ b/src/gobapi/dump/to_db.py
@@ -184,7 +184,8 @@ class DbDumper:
         # Delete tmp table if still exists from a previous run
         self._delete_tmp_table()
 
-        create_table = _create_table(self.schema, self.catalog_name, self.tmp_collection_name, self.model)
+        create_table = _create_table(self.schema, self.catalog_name, self.collection_name, self.model,
+                                     tablename=self.tmp_collection_name)
         self._execute(create_table)
 
     def _copy_tmp_table(self):

--- a/src/tests/dump/test_sql.py
+++ b/src/tests/dump/test_sql.py
@@ -61,6 +61,11 @@ class TestSQL(TestCase):
             self.assertTrue(f"\"a_{s}\"" in result)
             self.assertTrue(f"character varying" in result)
 
+        # With alternative tablename (used for tmp table)
+        result = _create_table('any_schema', catalogue, 'any_table', {}, tablename='the table name')
+        self.assertTrue("CREATE TABLE IF NOT EXISTS \"any_schema\".\"the table name\"" in result)
+        self.assertTrue("COMMENT ON TABLE  \"any_schema\".\"the table name\"" in result)
+
     def test_import_csv(self):
         result = _import_csv('any_schema', 'any_collection', 'any_collection.csv')
         self.assertTrue("\COPY \"any_schema\".\"any_collection\" FROM 'any_collection.csv'" in result)

--- a/src/tests/dump/test_to_db.py
+++ b/src/tests/dump/test_to_db.py
@@ -199,8 +199,9 @@ class TestDbDumper(TestCase):
         mock_table.assert_called_with(
             db_dumper.schema,
             self.catalog_name,
-            db_dumper.tmp_collection_name,
+            db_dumper.collection_name,
             db_dumper.model,
+            tablename=db_dumper.tmp_collection_name
         )
 
 


### PR DESCRIPTION
Tablename used to be the provided collection naem, but that same collection name was used to determine authorisation as well from the model.
For a tmp_ table the authorisation was done incorrectly (because the tmp_ table wasn't in the model). Use collection name to determine
authorisation and add a separate tablename parameter to name the tmp_ table.