### PR TITLE
Fix security hole

### DIFF
--- a/src/gobapi/auth/auth_query.py
+++ b/src/gobapi/auth/auth_query.py
@@ -246,9 +246,14 @@ class AuthorizedQuery(Query):
             secure_columns = {}
 
         for entity in super().__iter__():
-            self._suppress_columns(entity, suppressed_columns)
-            self._handle_secure_columns(entity, secure_columns)
-            yield entity
+            for entity in super().__iter__():
+                if isinstance(entity, tuple):
+                    self._suppress_columns(entity[0], suppressed_columns)
+                    self._handle_secure_columns(entity[0], secure_columns)
+                else:
+                    self._suppress_columns(entity, suppressed_columns)
+                    self._handle_secure_columns(entity, secure_columns)
+                yield entity
 
     def _handle_secure_columns(self, entity, secure_columns):
         for column, info in secure_columns.items():

--- a/src/tests/auth/test_auth_query.py
+++ b/src/tests/auth/test_auth_query.py
@@ -151,6 +151,16 @@ class TestAuthorizedQueryIter(TestCase):
         # Do not fail on set suppressed columns
         q.set_suppressed_columns(None, ["a"])
 
+        mock_super.return_value = iter([(MockEntity(),), (MockEntity(),)])
+        q = AuthorizedQuery()
+        q._authority = mock.MagicMock()
+        q._authority.get_suppressed_columns = lambda: ["a", "b", "some other col"]
+        for result in q:
+            self.assertIsNone(result[0].a)
+            self.assertIsNone(result[0].b)
+            self.assertFalse(hasattr(result[0], "some other col"))
+            self.assertIsNotNone(result[0].c)
+
     @patch("gobapi.auth.auth_query.super")
     def test_iter_unauthorized(self, mock_super):
         mock_super.return_value = iter([MockEntity(), MockEntity()])


### PR DESCRIPTION
While preparing the GOB demo I noticed that secure fields
where shown in the REST API.

This fix corrects the bug by checking if the entity is a tuple
and then secure the first element in the tuple
which is the entity