### PR TITLE
Fix small bug in graphql streaming API

### DIFF
--- a/src/gobapi/graphql_streaming/graphql2sql/graphql2sql.py
+++ b/src/gobapi/graphql_streaming/graphql2sql/graphql2sql.py
@@ -232,7 +232,7 @@ class SqlGenerator:
             self._validate_attribute(relation_info, attribute, relation_name)
 
     def _validate_attribute(self, relation_info: dict, attribute: str, relation_name: str):
-        if to_snake(attribute) not in relation_info['all_fields'] + [FIELD.SOURCE_VALUE, FIELD.SOURCE_INFO]:
+        if to_snake(attribute) not in list(relation_info['all_fields']) + [FIELD.SOURCE_VALUE, FIELD.SOURCE_INFO]:
             raise InvalidQueryException(f"Attribute {attribute} does not exist for {relation_name}")
 
     def _select_expression(self, relation: dict, field: str):


### PR DESCRIPTION
relation_info['all_fields'] is a dict and could not be added to the list 