### PR TITLE
Revert `antlr4-python3-runtime` version to 4.7.2

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,5 @@
 aniso8601==7.0.0
-antlr4-python3-runtime==4.9.2
+antlr4-python3-runtime==4.7.2
 Flask==1.1.2
 Flask-Cors==3.0.10
 Flask-GraphQL==2.0.1


### PR DESCRIPTION
fix warnings: ANTLR runtime and generated code versions disagree: 4.9.2!=4.7.2