### PR TITLE
Make database name configurable.

### DIFF
--- a/src/gobapi/config.py
+++ b/src/gobapi/config.py
@@ -14,6 +14,7 @@ API_SECURE_BASE_PATH = '/gob'
 
 GOB_DB = {
     'drivername': 'postgres',
+    'database': os.getenv('DATABASE_NAME', "gob"),
     'username': os.getenv("DATABASE_USER", "gob"),
     'password': os.getenv("DATABASE_PASSWORD", "insecure"),
     'host': os.getenv("DATABASE_HOST_OVERRIDE", "localhost"),


### PR DESCRIPTION
Database name is needed for Azure PostgreSQL, here
the username is <name>@<host>. That is why the
default scheme of $user does not work.