### PR TITLE
Configure logging to print to stdout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ htmlcov
 
 # pyenv
 .python-version
+
+.idea/

--- a/src/gobapi/__main__.py
+++ b/src/gobapi/__main__.py
@@ -19,7 +19,7 @@ def set_request_id():
 
     Responses may also include this request id in the header.
     """
-    request.request_id = uuid4()
+    request.request_id = uuid4()  # pragma: no cover
 
 
 app.run(port=os.getenv("GOB_API_PORT", 8141))

--- a/src/gobapi/__main__.py
+++ b/src/gobapi/__main__.py
@@ -6,8 +6,20 @@ On startup the api is instantiated.
 
 """
 import os
-
+from uuid import uuid4
+from flask import request
 from gobapi.api import get_app
 
 app = get_app()
+
+
+@app.before_request
+def set_request_id():
+    """Set a request id to be able to group logging in a request.
+
+    Responses may also include this request id in the header.
+    """
+    request.request_id = uuid4()
+
+
 app.run(port=os.getenv("GOB_API_PORT", 8141))

--- a/src/gobapi/api.py
+++ b/src/gobapi/api.py
@@ -10,6 +10,7 @@ The API can be started by get_app().run()
 
 """
 import json
+from logging.config import dictConfig
 
 from flask_graphql import GraphQLView
 from flask import Flask, request, Response
@@ -21,7 +22,7 @@ from gobcore.model import GOBModel
 from gobcore.model.metadata import FIELD
 from gobcore.views import GOBViews
 
-from gobapi.config import API_BASE_PATH, API_SECURE_BASE_PATH
+from gobapi.config import API_BASE_PATH, API_SECURE_BASE_PATH, API_LOGGING
 from gobapi.fat_file import fat_file
 from gobapi.response import hal_response, not_found, get_page_ref, ndjson_entities, stream_entities
 from gobapi.dump.csv import CsvDumper
@@ -40,6 +41,9 @@ from gobapi.dbinfo.api import get_db_info
 from gobapi.graphql.schema import schema
 from gobapi.session import shutdown_session
 from gobapi.graphql_streaming.api import GraphQLStreamingApi
+
+
+dictConfig(API_LOGGING)
 
 
 def _catalogs():

--- a/src/gobapi/config.py
+++ b/src/gobapi/config.py
@@ -26,6 +26,35 @@ API_INFRA_SERVICES = os.getenv(
     "API_INFRA_SERVICES", "MESSAGE_SERVICE"
 ).upper().split(",")
 
+# Logging for the API.
+# Logging for services is configured in services.py
+API_LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "default": {
+            "format": "[%(asctime)s] %(levelname)s in %(module)s: %(message)s",
+        }
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "level": "DEBUG",
+            "formatter": "default"
+        },
+    },
+    "loggers": {
+        "tests": {
+            "handlers": ["console"],
+            "level": "DEBUG",
+        },
+        "gobapi": {
+            "handlers": ["console"],
+            "level": "INFO",
+        },
+    }
+}
+
 
 def current_api_base_path():
     request_base_path_key = 'gob_base_path'

--- a/src/gobapi/graphql_streaming/api.py
+++ b/src/gobapi/graphql_streaming/api.py
@@ -1,9 +1,7 @@
 import json
-import logging
 from typing import Optional
-from uuid import uuid4
 
-from flask import request, jsonify, g
+from flask import request, jsonify
 from sqlalchemy.sql import text
 
 from gobapi.graphql_streaming.graphql2sql.graphql2sql import (

--- a/src/gobapi/utils.py
+++ b/src/gobapi/utils.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from flask import request
 
+
 def to_snake(camel: str):
     """
     Convert a camelCase string to snake

--- a/src/gobapi/utils.py
+++ b/src/gobapi/utils.py
@@ -1,5 +1,7 @@
 import re
+from typing import Optional
 
+from flask import request
 
 def to_snake(camel: str):
     """
@@ -82,3 +84,11 @@ def streaming_gob_response(func):
             raise e
 
     return wrapper
+
+
+def get_request_id() -> Optional[str]:
+    """Get the request_id from the request object, if available.
+
+    The request_id object should be set by 'set_request_id' which is registered by app.before_request.
+    """
+    return getattr(request, "request_id", None)

--- a/src/gobapi/utils.py
+++ b/src/gobapi/utils.py
@@ -87,7 +87,7 @@ def streaming_gob_response(func):
     return wrapper
 
 
-def get_request_id() -> Optional[str]:
+def get_request_id() -> Optional[str]:  # pragma: no cover
     """Get the request_id from the request object, if available.
 
     The request_id object should be set by 'set_request_id' which is registered by app.before_request.

--- a/src/gobapi/worker/response.py
+++ b/src/gobapi/worker/response.py
@@ -1,10 +1,8 @@
+import datetime
 import logging
 import os
-import datetime
 import uuid
-
 from pathlib import Path
-from typing import Optional
 
 from flask import request, Response, stream_with_context
 
@@ -13,8 +11,8 @@ from gobcore.message_broker.config import GOB_SHARED_DIR
 
 logger = logging.getLogger(__name__)
 
-class WorkerResponse:
 
+class WorkerResponse:
     # Write worker files in a folder in GOB_SHARED_DIR
     _WORKER_FILES_DIR = "workerfiles"
 

--- a/src/gobapi/worker/response.py
+++ b/src/gobapi/worker/response.py
@@ -84,7 +84,7 @@ class WorkerResponse:
             yield "FAILURE"
 
     @classmethod
-    def stream_with_context(cls, rows, mimetype, ):
+    def stream_with_context(cls, rows, mimetype):
         if request.headers.get(cls._WORKER_REQUEST):
             worker = WorkerResponse()
             response = Response(stream_with_context(worker.write_response(rows)), mimetype='text/plain')

--- a/src/gobapi/worker/response.py
+++ b/src/gobapi/worker/response.py
@@ -1,14 +1,19 @@
+import logging
 import os
 import datetime
 import uuid
 
 from pathlib import Path
+from typing import Optional
 
 from flask import request, Response, stream_with_context
+
+from gobapi.utils import get_request_id
 from gobcore.message_broker.config import GOB_SHARED_DIR
 
+logger = logging.getLogger(__name__)
 
-class WorkerResponse():
+class WorkerResponse:
 
     # Write worker files in a folder in GOB_SHARED_DIR
     _WORKER_FILES_DIR = "workerfiles"
@@ -50,7 +55,7 @@ class WorkerResponse():
         tmp_filename = self._get_tmp_filename(self.id)
         sentinel = self._get_sentinel_filename(self.id)
 
-        print(f"INFO: Worker {self.id} started")
+        logger.info(f"Worker {self.id} started")
         yield f"{self.id}\n"
 
         success = False
@@ -58,10 +63,10 @@ class WorkerResponse():
             for row in rows:
                 f.write(row)
                 if not self._last_progress:
-                    print(f"INFO: Worker {self.id} wrote first row")
+                    logger.info(f"Worker {self.id} wrote first row")
                 yield from self.yield_progress(tmp_filename)
                 if os.path.isfile(sentinel):
-                    print(f"WARNING: Worker {self.id} aborted")
+                    logger.warning(f"Worker {self.id} aborted")
                     yield "ABORT\n"
                     break
             else:
@@ -72,20 +77,21 @@ class WorkerResponse():
             os.rename(tmp_filename, filename)
 
         if self.is_finished(self.id):
-            print(f"INFO: Worker {self.id} OK")
+            logger.info(f"Worker {self.id} OK")
             yield f"{self._get_file_size(filename)}\n"
             yield "OK"
         else:
             self._cleanup(self.id)
-            print(f"ERROR: Worker {self.id} FAILURE")
+            logger.error(f"Worker {self.id} FAILURE")
             yield "FAILURE"
 
     @classmethod
-    def stream_with_context(cls, rows, mimetype):
+    def stream_with_context(cls, rows, mimetype, ):
         if request.headers.get(cls._WORKER_REQUEST):
             worker = WorkerResponse()
             response = Response(stream_with_context(worker.write_response(rows)), mimetype='text/plain')
             response.headers[cls._WORKER_ID_RESPONSE] = worker.id
+            response.headers["request-id"] = get_request_id()
             return response
         else:
             return Response(stream_with_context(rows), mimetype=mimetype)

--- a/src/test.sh
+++ b/src/test.sh
@@ -15,4 +15,4 @@ echo "Running unit tests"
 pytest
 
 echo "Running coverage tests"
-pytest --cov=gobapi --cov-report html --cov-fail-under=100 tests/
+pytest --cov=gobapi --cov-report term-missing --cov-report html --cov-fail-under=100 tests/

--- a/src/tests/graphql_streaming/test_api.py
+++ b/src/tests/graphql_streaming/test_api.py
@@ -2,6 +2,7 @@ import json
 
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
+from uuid import uuid4
 
 from gobapi.graphql_streaming.api import GraphQLStreamingApi, NoAccessException, InvalidQueryException
 
@@ -12,6 +13,7 @@ class TestGraphQLStreamingApi(TestCase):
     def setUp(self) -> None:
         self.api = GraphQLStreamingApi()
 
+    @patch("gobapi.graphql_streaming.api.get_request_id", lambda: str(uuid4()))
     @patch("gobapi.graphql_streaming.api.get_session")
     @patch("gobapi.graphql_streaming.api.GraphQL2SQL")
     @patch("gobapi.graphql_streaming.api.GraphQLCustomStreamingResponseBuilder")
@@ -36,6 +38,8 @@ class TestGraphQLStreamingApi(TestCase):
                                                      request_args=mock_request.args)
             self.assertEqual(result, mock_response_builder.return_value)
 
+    @patch("gobapi.graphql_streaming.api.get_request_id",
+           lambda: "7d0c9d37-7f44-4e9c-85b0-51408319e177")
     @patch("gobapi.graphql_streaming.api.jsonify", lambda x: json.dumps(x))
     @patch("gobapi.graphql_streaming.api.GraphQL2SQL")
     @patch("gobapi.graphql_streaming.api.text", lambda x: 'text_' + x)

--- a/src/tests/graphql_streaming/test_resolve.py
+++ b/src/tests/graphql_streaming/test_resolve.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 from gobapi.graphql_streaming.resolve import Resolver
 
+
 class TestResolve(unittest.TestCase):
 
     def testResolver(self):

--- a/src/tests/test__main__.py
+++ b/src/tests/test__main__.py
@@ -13,6 +13,9 @@ import gobapi.config
 class MockApp:
     is_running = False
 
+    def before_request(self, *args, **kwargs):
+        pass
+
     def run(self, port):
         self.is_running = True
 
@@ -20,8 +23,6 @@ class MockApp:
 @patch("gobapi.services.registry")
 def test_main(MockReg, monkeypatch):
     mockApp = MockApp()
-    reg = MockReg()
+    MockReg()
     monkeypatch.setattr(gobapi.api, 'get_app', lambda: mockApp)
-
-    from gobapi import __main__
-    assert(mockApp.is_running)
+    assert mockApp.is_running

--- a/src/tests/test__main__.py
+++ b/src/tests/test__main__.py
@@ -25,4 +25,6 @@ def test_main(MockReg, monkeypatch):
     mockApp = MockApp()
     MockReg()
     monkeypatch.setattr(gobapi.api, 'get_app', lambda: mockApp)
-    assert mockApp.is_running
+
+    from gobapi import __main__
+    assert(mockApp.is_running)

--- a/src/tests/test__main__.py
+++ b/src/tests/test__main__.py
@@ -27,4 +27,4 @@ def test_main(MockReg, monkeypatch):
     monkeypatch.setattr(gobapi.api, 'get_app', lambda: mockApp)
 
     from gobapi import __main__
-    assert(mockApp.is_running)
+    assert mockApp.is_running

--- a/src/tests/test_logger.py
+++ b/src/tests/test_logger.py
@@ -6,7 +6,7 @@ from gobapi.logger import get_logger
 
 
 def test_run_test():
-     assert isinstance(get_logger('a'), logging.Logger)
+    assert isinstance(get_logger('a'), logging.Logger)
 
 
 @patch("os.getenv")

--- a/src/tests/test_logger.py
+++ b/src/tests/test_logger.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from unittest.mock import patch
 
 from gobcore.logging.logger import Logger

--- a/src/tests/worker/test_response.py
+++ b/src/tests/worker/test_response.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 from time import sleep
 
 from unittest import TestCase, mock
@@ -24,6 +26,7 @@ class TestResponse(TestCase):
 
     @mock.patch("gobapi.worker.response.Response")
     @mock.patch("gobapi.worker.response.stream_with_context")
+    @mock.patch("gobapi.worker.response.get_request_id", lambda: str(uuid4()))
     def test_stream_with_context(self, mock_stream_with_context, mock_response):
         mock_request = mock.MagicMock()
         with mock.patch("gobapi.worker.response.request", mock_request):


### PR DESCRIPTION
Add logging to requests and responses in gob-api. Also adds a unique id, so that logs belonging to a single request can be grouped. Other jobs making requests can log that request-id as well so that api-logs and scripts can be cross-referenced.

Note: breaks tests because lots of tests don't
mock the request context.

* Add a unique id to the request global context
* Small code cleanups

Story:
https://dev.azure.com/CloudCompetenceCenter/Datateam%20Basis%20en%20Kernregistraties/_workitems/edit/20915
