### PR TITLE
Include public meta fields in graphql api

### DIFF
--- a/src/gobapi/auth/auth_query.py
+++ b/src/gobapi/auth/auth_query.py
@@ -2,7 +2,7 @@ from sqlalchemy.orm import Query
 from flask import request
 
 from gobcore.secure.user import User
-from gobcore.model import GOBModel
+from gobcore.model import GOBModel, PUBLIC_META_FIELDS
 from gobcore.typesystem import get_gob_type_from_info, gob_types, gob_secure_types
 
 from gobapi.auth.schemes import GOB_AUTH_SCHEME
@@ -21,7 +21,7 @@ class Authority:
         self._catalog = catalog_name
         self._collection = collection_name
         collection = GOBModel().get_collection(self._catalog, self._collection)
-        self._attributes = [attr for attr in collection['fields']] if collection else []
+        self._attributes = [attr for attr in collection['fields'] | PUBLIC_META_FIELDS] if collection else []
         self._auth_scheme = GOB_AUTH_SCHEME
         self._secured_columns = None
         self._suppressed_columns = None

--- a/src/gobapi/graphql/__init__.py
+++ b/src/gobapi/graphql/__init__.py
@@ -3,7 +3,7 @@
 """
 import graphene
 
-from gobcore.model.metadata import PRIVATE_META_FIELDS, PUBLIC_META_FIELDS, FIXED_FIELDS
+from gobcore.model.metadata import PRIVATE_META_FIELDS, FIXED_FIELDS
 from gobapi.graphql.scalars import Date, DateTime, GeoJSON, Scalar
 from graphql.language.ast import IntValue
 
@@ -65,8 +65,4 @@ def graphene_type(gob_typename, description=""):
 
 
 # Not all GOB fields are exposed in the GraphQL interface
-exclude_fields = tuple(name for name in {
-    **PRIVATE_META_FIELDS,
-    **PUBLIC_META_FIELDS,
-    **FIXED_FIELDS
-}.keys())
+exclude_fields = tuple(name for name in {**PRIVATE_META_FIELDS, **FIXED_FIELDS}.keys())

--- a/src/gobapi/graphql_streaming/response.py
+++ b/src/gobapi/graphql_streaming/response.py
@@ -235,7 +235,7 @@ class GraphQLStreamingResponseBuilder:
             row = dict_to_camelcase(row)
             built_entity = None
 
-            if row[FIELD.GOBID] != self.last_id and self.last_id is not None:
+            if self.last_id is not None and row[FIELD.GOBID] != self.last_id:
                 # Build entity when all rows of same GOBID are collected
                 built_entity = self._build_entity(collected_rows)
                 collected_rows = []

--- a/src/tests/dump/test_sql.py
+++ b/src/tests/dump/test_sql.py
@@ -82,7 +82,7 @@ class TestSQL(TestCase):
 
     def test_import_csv(self):
         result = _import_csv('any_schema', 'any_collection', 'any_collection.csv')
-        self.assertTrue("\COPY \"any_schema\".\"any_collection\" FROM 'any_collection.csv'" in result)
+        self.assertTrue("COPY \"any_schema\".\"any_collection\" FROM 'any_collection.csv'" in result)
 
     @patch('gobapi.dump.sql.Authority', MagicMock())
     @patch('gobapi.dump.sql.GOBModel', MagicMock())
@@ -97,7 +97,7 @@ class TestSQL(TestCase):
         result = sql_entities('any catalog', 'any collection', {})
         self.assertTrue("CREATE SCHEMA IF NOT EXISTS" in result)
         self.assertTrue("CREATE TABLE IF NOT EXISTS" in result)
-        self.assertTrue("\COPY" in result)
+        self.assertTrue("COPY" in result)
         mock_create.assert_called()
 
     def test_quoted_tablename(self):

--- a/src/tests/graphql/test_schema.py
+++ b/src/tests/graphql/test_schema.py
@@ -13,7 +13,7 @@ class TestGraphqlSchema(TestCase):
             def get_catalogs(self):
                 return {}
 
-        assert(_get_sorted_references(MockModel()) == [])
+        assert (_get_sorted_references(MockModel()) == [])
 
     def test_sorted_references(self):
         class MockModel():
@@ -27,10 +27,10 @@ class TestGraphqlSchema(TestCase):
                 }
 
             def get_collections(self, catalog_name):
-                refs_1 = {"attr1" : self.ref_to("catalog:collection3")}
-                refs_2 = {"attr1" : self.ref_to("catalog:collection1")}
+                refs_1 = {"attr1": self.ref_to("catalog:collection3")}
+                refs_2 = {"attr1": self.ref_to("catalog:collection1")}
                 refs_3 = {}
-                refs_4 = {"attr1" : self.ref_to("catalog:collection2")}
+                refs_4 = {"attr1": self.ref_to("catalog:collection2")}
                 return {
                     "collection1": {
                         "references": refs_1,
@@ -52,11 +52,11 @@ class TestGraphqlSchema(TestCase):
 
         sorted_refs = _get_sorted_references(MockModel())
         # 1 => 3 implies 3 before 1
-        assert(sorted_refs.index('catalog:collection3') < sorted_refs.index('catalog:collection1'))
+        assert (sorted_refs.index('catalog:collection3') < sorted_refs.index('catalog:collection1'))
         # 2 => 1 implies 1 before 2
-        assert(sorted_refs.index('catalog:collection1') < sorted_refs.index('catalog:collection2'))
+        assert (sorted_refs.index('catalog:collection1') < sorted_refs.index('catalog:collection2'))
         # 4 => 2 implies 2 before 4
-        assert(sorted_refs.index('catalog:collection2') < sorted_refs.index('catalog:collection4'))
+        assert (sorted_refs.index('catalog:collection2') < sorted_refs.index('catalog:collection4'))
 
     @patch("gobapi.graphql.schema.inverse_connection_fields", {"fielda": "vala", "fieldb": "valb"})
     def test_get_inverse_connection_field_keyerror(self):
@@ -74,13 +74,15 @@ class TestGraphqlSchema(TestCase):
     @patch("gobapi.graphql.schema.models", MockModels())
     def test_get_inverse_relation_resolvers(self, mock_model, mock_resolve):
         connections = [
-            {'src_catalog': 'cata', 'src_collection': 'cola', 'src_relation_name': 'relation_a', 'field_name': 'field_a'},
-            {'src_catalog': 'catb', 'src_collection': 'colb', 'src_relation_name': 'relation_b', 'field_name': 'field_b'},
+            {'src_catalog': 'cata', 'src_collection': 'cola', 'src_relation_name': 'relation_a',
+             'field_name': 'field_a'},
+            {'src_catalog': 'catb', 'src_collection': 'colb', 'src_relation_name': 'relation_b',
+             'field_name': 'field_b'},
         ]
         mock_model.get_table_name.side_effect = ['table_name_a', 'table_name_b']
         mock_model._data = {
-            'cata': { 'collections': { 'cola': { 'attributes': { 'relation_a': { 'type': 'GOB.ManyReference'}}}}},
-            'catb': { 'collections': { 'colb': { 'attributes': { 'relation_b': { 'type': 'GOB.Reference'}}}}},
+            'cata': {'collections': {'cola': {'attributes': {'relation_a': {'type': 'GOB.ManyReference'}}}}},
+            'catb': {'collections': {'colb': {'attributes': {'relation_b': {'type': 'GOB.Reference'}}}}},
 
         }
         mock_resolve.side_effect = ['resolver a', 'resolver b']

--- a/src/tests/graphql_streaming/graphql2sql/test_graphql2sql.py
+++ b/src/tests/graphql_streaming/graphql2sql/test_graphql2sql.py
@@ -625,7 +625,7 @@ ORDER BY colb_0._gobid
     ]
 
     def normalise_whitespace(self, string: str):
-        whitespacechars = re.sub(r'([,(,)])', ' \g<1> ', string)
+        whitespacechars = re.sub(r'([,(,)])', ' g<1> ', string)
         return re.sub(r'\s+', ' ', whitespacechars).strip()
 
     def assertResult(self, input, expected_result, result):


### PR DESCRIPTION
This PR allows the `PUBLIC_META_FIELDS` to be queried from the graphql endpoint(s). (Streaming and graphiql)

public meta fields includes:
- date modfied
- date confirmed
- date created
- date deleted
- version
- expiration date