### PR TITLE
Fix issue with dump job for AMS Schema migrated collections

### DIFF
--- a/src/gobapi/dump/to_db.py
+++ b/src/gobapi/dump/to_db.py
@@ -496,6 +496,7 @@ def dump_to_db(catalog_name, collection_name, config):
     except Exception as e:
         print("Dump failed", traceback.format_exc(limit=-5))
         yield f"ERROR: Dump failed - {str(e)}\n"
+        raise e
     finally:
         if dumper:
             dumper.disconnect()

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -18,4 +18,4 @@ Rx==1.6.1
 singledispatch==3.7.0
 Werkzeug==2.0.3
 -e git+https://github.com/Amsterdam/flask-audit-log.git@v0.1.0a-rc1#egg=datapunt-flask-audit-log
--e git+https://github.com/Amsterdam/GOB-Core.git@v1.2.1#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v1.3.1#egg=gobcore

--- a/src/tests/dump/test_to_db.py
+++ b/src/tests/dump/test_to_db.py
@@ -843,9 +843,9 @@ class TestModuleFunctions(TestCase):
         list(dump_to_db('rel', 'collection_name', config))
         mock_dumper.return_value.create_utility_view.assert_not_called()
 
-
     def test_dump_to_db_exception(self, mock_dumper):
         mock_dumper.side_effect = Exception
 
-        result = "".join(list(dump_to_db('catalog_name', 'collection_name', {})))
-        self.assertIn("ERROR: Dump failed", result)
+        with self.assertRaises(Exception):
+            result = "".join(list(dump_to_db('catalog_name', 'collection_name', {})))
+            self.assertIn("ERROR: Dump failed", result)

--- a/src/tests/legacy_views/test_create.py
+++ b/src/tests/legacy_views/test_create.py
@@ -63,6 +63,7 @@ class MockRelations:
             'collections': {
                 'gbd_brt_abc_abc': {},
                 'gbd_brt_def_def': {},
+                'nap_pmk_gbd_bbk_ligt_in_bouwblok': {}
             }
         }
 
@@ -109,4 +110,7 @@ FROM public.rel_nap_pmk_gbd_bbk_ligt_in_gebieden_bouwblok"""
             call(f"CREATE OR REPLACE VIEW legacy.rel_nap_pmk_gbd_bbk_ligt_in_bouwblok AS {expected_rel_query}"),
             call("CREATE OR REPLACE VIEW legacy.mv_gbd_brt_abc_abc AS SELECT * FROM public.mv_gbd_brt_abc_abc"),
             call("CREATE OR REPLACE VIEW legacy.mv_gbd_brt_def_def AS SELECT * FROM public.mv_gbd_brt_def_def"),
+
+            # With overridden tablename
+            call("CREATE OR REPLACE VIEW legacy.mv_nap_pmk_gbd_bbk_ligt_in_bouwblok AS SELECT * FROM public.mv_nap_pmk_gbd_bbk_ligt_in_gebieden_bouwblok")
         ])


### PR DESCRIPTION
Relations for legacy models were not initialised correctly in API. Fixed in Core, and adjusted the init scripts in this repo to be able to work with the fix.

Also raising exception from API (instead of ignoring the real exception), so that the logging is visible in Kibana