### PR TITLE
Only migrate legacy views on first worker run

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       UWSGI_BUFFER_SIZE: "8192"
       UWSGI_DIE_ON_TERM: "1"
       UWSGI_NEED_APP: "1"
+      UWSGI_CACHE2: "name=mycache,items=5"
       # UWSGI_ATTACH_DAEMON2: "cmd=./oauth2-proxy --config oauth2-proxy.cfg,freq=3,control=true,stopsignal=15"
 
       # uWSGI timeouts set to 8 hours


### PR DESCRIPTION
Use uWSGI cache feature to set a variable for all workers. All workers can safely get this value concurrently. We only need to migrate once on a application start. After that on a worker restart, the migration can be skipped. This prevents locking the database.

#60939