### PR TITLE
Set Oauth2-proxy timeout to 3600s

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,25 +23,33 @@ services:
       SECURE_SALT: insecure
       SECURE_PASSWORD: insecure
 
-      # OAuth2 Proxy listens on port 8000 and serves as a proxy for UWSGI
       UWSGI_HTTP: ":8001"
       UWSGI_MODULE: "gobapi.wsgi"
       UWSGI_CALLABLE: "application"
       UWSGI_MASTER: "1"
-      UWSGI_ENABLE_THREADS: ""
-      UWSGI_PROCESSES: "4"
+      UWSGI_ENABLE_THREADS: "1"
+      UWSGI_PROCESSES: "6"
       UWSGI_LAZY_APPS: "1"
       UWSGI_BUFFER_SIZE: "8192"
       UWSGI_DIE_ON_TERM: "1"
       UWSGI_NEED_APP: "1"
-      UWSGI_CACHE2: "name=mycache,items=5"
-      # UWSGI_ATTACH_DAEMON2: "cmd=./oauth2-proxy --config oauth2-proxy.cfg,freq=3,control=true,stopsignal=15"
-
-      # uWSGI timeouts set to 8 hours
+      UWSGI_ATTACH_DAEMON2: "cmd=./oauth2-proxy --config oauth2-proxy.cfg,freq=3,control=true,stopsignal=15"
       UWSGI_HARAKIRI: "28800"
-      UWSGI_MAX_WORKER_LIFETIME: "28800"
       UWSGI_HTTP_TIMEOUT: "28800"
       UWSGI_SOCKET_TIMEOUT: "28800"
+      UWSGI_STRICT: "1"
+      UWSGI_VACUUM: "1"
+      UWSGI_SINGLE_INTERPRETER: "1"
+      UWSGI_ROUTE: "^/status/health break:200 OK"
+      UWSGI_CACHE2: "name=mycache,items=5"
+
+      # uWSGI Cheaper, make sure we always have minimum of 4 workers and scale to <PROCESSES>
+      UWSGI_CHEAPER: "4"
+      UWSGI_CHEAPER_ALGO: "spare"
+      UWSGI_CHEAPER_INITIAL: "4"
+      UWSGI_CHEAPER_STEP: "1"
+      UWSGI_CHEAPER_OVERLOAD: "5"
+      UWSGI_MIN_WORKER_LIFETIME: "1800"
 
       OAUTH2_PROXY_CLIENT_ID: ${OAUTH2_PROXY_CLIENT_ID}
       OAUTH2_PROXY_CLIENT_SECRET: ${OAUTH2_PROXY_CLIENT_SECRET}

--- a/src/oauth2-proxy.cfg
+++ b/src/oauth2-proxy.cfg
@@ -4,7 +4,7 @@ provider="oidc"
 http_address="0.0.0.0:8000"
 upstreams="http://127.0.0.1:8001"
 # timeout needs to be this size to allow for slow requests (ie graphql_streaming)
-upstream_timeout="1200s"
+upstream_timeout="3600s"
 email_domains="*"
 proxy_prefix="/gob/oauth"
 oidc_email_claim="preferred_username"


### PR DESCRIPTION
It takes a lot of time to generate a first response for graphql_streaming endpoint. Used for example in brk kadastraleobjecten export. Try setting the timeout to 1 hour.