### PR TITLE
slim-bullseye with current Python 3.9.x and GOB-Core.

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,10 +1,10 @@
 # syntax=docker/dockerfile:1
-FROM amsterdam/gob_wheelhouse:3.9-bullseye as wheelhouse
+FROM amsterdam/gob_wheelhouse:3.9-slim-bullseye as wheelhouse
 MAINTAINER datapunt@amsterdam.nl
 
 
 # Application stage.
-FROM amsterdam/gob_baseimage:3.9-bullseye as application
+FROM amsterdam/gob_baseimage:3.9-slim-bullseye as application
 MAINTAINER datapunt@amsterdam.nl
 # GOB base image: SQL Server driver.
 
@@ -12,7 +12,8 @@ MAINTAINER datapunt@amsterdam.nl
 COPY --from=wheelhouse /opt/wheelhouse /opt/wheelhouse
 
 # Install ANTLR for build.sh (GraphQL 2 SQL grammar).
-RUN apt-get install -y antlr4
+RUN apt-get update && apt-get install -y antlr4
+RUN rm -rf /var/lib/apt/lists/*
 
 # Install gobapi service in /app folder.
 WORKDIR /app
@@ -56,6 +57,7 @@ USER datapunt
 # Test.
 FROM application as test
 USER root
+
 # Remove gobcore tests
 RUN rm -rf /app/src/gobcore/tests
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -15,4 +15,4 @@ PyYAML==6.0.1
 Rx==1.6.1
 singledispatch~=3.7.0
 -e git+https://github.com/Amsterdam/flask-audit-log.git@v0.1.0a-rc1#egg=datapunt-flask-audit-log
-git+https://github.com/Amsterdam/GOB-Core.git@v2.22.0
+git+https://github.com/Amsterdam/GOB-Core.git@v2.23.0


### PR DESCRIPTION
slim-bullseye met Python 3.9.18 en vanwege `gobcore.model.amschema.repo.AMSchemaError: Table maatschappelijkeactiviteiten/2.7.0 does not exist in dataset hr`